### PR TITLE
#41 change import neclib EnvVarName

### DIFF
--- a/observer/server.py
+++ b/observer/server.py
@@ -10,7 +10,7 @@ import rclpy
 import tomlkit
 from flask import Flask, Response, escape, redirect, render_template, request, url_for
 from flask_socketio import SocketIO, join_room, leave_room
-from neclib import EnvVarName
+from neclib.core import environ
 
 from .address import get_ip_address
 from .client_manager import ClientManager, get_msg_type
@@ -46,7 +46,7 @@ def qlook() -> str:
 def config_file(filename: str) -> str:
     path = Path.home() / ".necst" / filename
     if not path.exists():
-        os.environ.pop(EnvVarName.necst_root, None)
+        os.environ.pop(environ.necst_root.name, None)
         neclib.configure()
 
     try:
@@ -59,7 +59,7 @@ def config_file(filename: str) -> str:
 def config() -> str:
     path = Path.home() / ".necst"
     if not path.exists():
-        os.environ.pop(EnvVarName.necst_root, None)
+        os.environ.pop(environ.necst_root.name, None)
         neclib.configure()
 
     files = filter(lambda x: x.is_file(), path.glob("**/*"))
@@ -75,7 +75,7 @@ def config_edit(filename: str) -> str:
 
     if request.method == "GET":
         if not path.exists():
-            os.environ.pop(EnvVarName.necst_root, None)
+            os.environ.pop(environ.necst_root.name, None)
             neclib.configure()
 
         try:


### PR DESCRIPTION
**Checks**

- [x] Debugging completed
- [ ] Please debug me

- DockerFileを書き換えた関係で最新のnecstとそのDockerFileで指定された新しいneclibが入るようになりましたが、necst内部で参照する環境変数を代入するClass `EnvVarName`が最新版ではなくなっており、importに失敗する現象が見つかったので修正しました。
- この変更を適応した状態で動作試験を行いましたが正常に動くことを確認しました。
  - この変更はConfigを編集する関数周辺でのみ参照されます。正常にconfigファイル、pointing_configファイルが更新されることを確認しました。
- リリースをしない場合ghrc経由でインストール＆実行した時にimport errorが発生する可能性があるので、近日リリースをしなければならない可能性があります。