### PR TITLE
fix: add --break-system-packages to pip install astropy

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ ENV POETRY_VIRTUALENVS_CREATE=false
 ENV PATH=$PATH:/root/.local/bin
 RUN curl -sSL https://install.python-poetry.org | python3 - \
     && apt-get install python-is-python3
-RUN pip install -U astropy
+RUN pip install -U astropy --break-system-packages
 
 COPY . /root/observer
 


### PR DESCRIPTION
## Summary
- `pip install -U astropy` が PEP 668 (Python 3.12 / Ubuntu 24.04) で失敗していたため `--break-system-packages` を追加

## Test plan
- [ ] Docker image ビルドが成功することを確認