### PR TITLE
fix: add --break-system-packages to pip install for Python 3.12+

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ ENV POETRY_VIRTUALENVS_CREATE=false
 ENV PATH=$PATH:/root/.local/bin
 RUN curl -sSL https://install.python-poetry.org | python3 - \
     && apt-get install python-is-python3
-RUN pip install -U astropy
+RUN pip install --break-system-packages -U astropy
 
 COPY . /root/observer
 


### PR DESCRIPTION
## Summary

- `pip install -U astropy` in the Dockerfile fails on Ubuntu 24.04 with `externally-managed-environment` error (PEP 668)
- Added `--break-system-packages` flag to bypass this restriction

## Root cause

Ubuntu 24.04 ships with Python 3.12+ which enforces PEP 668, preventing bare `pip install` from modifying the system-managed Python environment. The CI runner image was updated to ubuntu-24.04, triggering this failure.

## Fix

```diff
-RUN pip install -U astropy
+RUN pip install --break-system-packages -U astropy
```

This is consistent with the existing `POETRY_VIRTUALENVS_CREATE=false` setup, which also installs packages directly into the system environment.

## Related

Fixes https://github.com/necst-telescope/observer/actions/runs/26651208810/job/78549762527