### PR TITLE
fix: set PIP_BREAK_SYSTEM_PACKAGES=1 to fix poetry install on Python 3.12+

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,9 +2,10 @@ FROM ghcr.io/necst-telescope/necst:v4.0.19
 
 ENV POETRY_VIRTUALENVS_CREATE=false
 ENV PATH=$PATH:/root/.local/bin
+ENV PIP_BREAK_SYSTEM_PACKAGES=1
 RUN curl -sSL https://install.python-poetry.org | python3 - \
     && apt-get install python-is-python3
-RUN pip install --break-system-packages -U astropy
+RUN pip install -U astropy
 
 COPY . /root/observer
 


### PR DESCRIPTION
## Summary

- `poetry install` fails in the Docker build with `externally-managed-environment` on Python 3.12+
- Poetry runs `pip uninstall` / `pip install` internally, and these are also blocked by PEP 668

## Root cause

The previous fix (#118) only added `--break-system-packages` to the explicit `pip install -U astropy` call. However, `poetry install` (with `POETRY_VIRTUALENVS_CREATE=false`) also invokes pip internally, which hits the same error.

## Fix

Replace the per-command flag with `ENV PIP_BREAK_SYSTEM_PACKAGES=1`, which applies to all pip invocations inside the container — including those made by Poetry.

## Related

Fixes https://github.com/necst-telescope/observer/actions/runs/26687449767/job/78657984088  
Follow-up to #118