### PR TITLE
fix: let Poetry use a virtualenv instead of polluting system Python

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,15 +1,16 @@
 FROM ghcr.io/necst-telescope/necst:v4.0.19
 
-ENV POETRY_VIRTUALENVS_CREATE=false
 ENV PATH=$PATH:/root/.local/bin
-ENV PIP_BREAK_SYSTEM_PACKAGES=1
 RUN curl -sSL https://install.python-poetry.org | python3 - \
     && apt-get install python-is-python3
-RUN pip install -U astropy
 
 COPY . /root/observer
 
-RUN ( cd /root/observer && poetry install )
+RUN cd /root/observer \
+    && poetry install \
+    && poetry run pip install -U astropy
+
+ENV PATH=/root/observer/.venv/bin:$PATH
 
 EXPOSE 8080
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/necst-telescope/necst:v4.0.19
+FROM ghcr.io/necst-telescope/necst:v4.0.20
 
 ENV PATH=$PATH:/root/.local/bin
 RUN curl -sSL https://install.python-poetry.org | python3 - \


### PR DESCRIPTION
## 根本原因

`POETRY_VIRTUALENVS_CREATE=false` によって Poetry がシステム Python にパッケージをインストールしようとしていた。Ubuntu 24.04 (Python 3.12) では:

1. PEP 668 により素の `pip install` がブロックされる
2. `lark` など apt 管理のパッケージは RECORD ファイルを持たず `pip uninstall` が失敗する

これらの衝突は個々にパッチを当て続けても、次のパッケージで同じ問題が再発する。

## 修正内容

- `POETRY_VIRTUALENVS_CREATE=false` を削除 → Poetry がデフォルトの venv (`/root/observer/.venv`) を使用
- `PIP_BREAK_SYSTEM_PACKAGES=1` も不要になるため削除
- `astropy` のインストールを `poetry run pip install` に変更 → venv 内にインストールされる
- `ENV PATH=/root/observer/.venv/bin:$PATH` を追加 → `observer` コマンドが venv 外からも呼べる

## Related

Supersedes #118, #119  
Fixes https://github.com/necst-telescope/observer/actions/runs/26687610272/job/78658409220