### PR TITLE
fix: allow venv to access system site-packages so neclib is importable

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,6 +10,7 @@ COPY . /root/observer
 
 RUN cd /root/observer \
     && poetry config virtualenvs.in-project true \
+    && poetry config virtualenvs.options.system-site-packages true \
     && poetry install \
     && poetry run pip install -U astropy
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,7 @@
 FROM ghcr.io/necst-telescope/necst:v4.0.20
 
 ENV PATH=$PATH:/root/.local/bin
+ENV PIP_BREAK_SYSTEM_PACKAGES=1
 
 RUN curl -sSL https://install.python-poetry.org | python3 - \
     && apt-get update \


### PR DESCRIPTION
## 原因

observer の Poetry venv はシステムPythonのパッケージを隔離するため、ベースイメージ（`necst:v4.0.20`）にインストールされた `neclib` が venv 内から参照できず、コンテナ起動時に以下のエラーが発生していた。

```
ModuleNotFoundError: No module named 'neclib'
```

エラーの伝播経路:
```
observer (venv) → necst をインポート → necst が neclib をインポート → ❌
```

## 修正内容

`poetry config virtualenvs.options.system-site-packages true` を追加し、venv がシステムPythonのパッケージも参照できるようにした。

## Test plan

- [ ] `docker build` が成功すること
- [ ] コンテナ起動時に `ModuleNotFoundError: No module named 'neclib'` が出ないこと