### PR TITLE
#122 fix: neclib not importable, pip/git unusable in container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,6 +10,7 @@ COPY . /root/observer
 
 RUN cd /root/observer \
     && poetry config virtualenvs.in-project true \
+    && poetry config virtualenvs.options.system-site-packages true \
     && poetry install \
     && poetry run pip install -U astropy
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,7 @@
 FROM ghcr.io/necst-telescope/necst:v4.0.20
 
 ENV PATH=$PATH:/root/.local/bin
+ENV PIP_BREAK_SYSTEM_PACKAGES=1
 
 RUN curl -sSL https://install.python-poetry.org | python3 - \
     && apt-get update \

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,6 +9,8 @@ RUN curl -sSL https://install.python-poetry.org | python3 - \
 
 COPY . /root/observer
 
+RUN git config --global credential.helper ""
+
 RUN cd /root/observer \
     && poetry config virtualenvs.in-project true \
     && poetry config virtualenvs.options.system-site-packages true \


### PR DESCRIPTION
Closes #122

## 原因と修正

### 1. `ModuleNotFoundError: No module named 'neclib'`

observer の Poetry venv はシステムPythonのパッケージを隔離するため、ベースイメージ (`necst:v4.0.20`) にインストールされた `neclib` が venv から見えずコンテナ起動時にクラッシュしていた。

→ `poetry config virtualenvs.options.system-site-packages true` を追加

### 2. pip が `--break-system-packages` なしで使えない（PEP 668）

→ `ENV PIP_BREAK_SYSTEM_PACKAGES=1` を設定

### 3. `git pull` がコンテナ内で認証を求める

`COPY . /root/observer` で Mac の `.git/` がコンテナに入り、`osxkeychain` credential helper の設定が影響していた。

→ `RUN git config --global credential.helper ""` を追加

## Test plan

- [ ] コンテナ起動時に `ModuleNotFoundError: No module named 'neclib'` が出ないこと
- [ ] `pip install` が `--break-system-packages` なしで実行できること
- [ ] コンテナ内で `git pull` が認証なしで成功すること