### PR TITLE
#124 fix: use GIT_TERMINAL_PROMPT=0 to suppress auth prompt in container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ RUN curl -sSL https://install.python-poetry.org | python3 - \
 
 COPY . /root/observer
 
-RUN git config --global credential.helper ""
+ENV GIT_TERMINAL_PROMPT=0
 
 RUN cd /root/observer \
     && poetry config virtualenvs.in-project true \


### PR DESCRIPTION
Closes #124

## 変更内容

`credential.helper ""` → `ENV GIT_TERMINAL_PROMPT=0` に置き換え。

前の修正（#122）では `credential.helper = ""` で helper を無効化していたが、git はターミナルに直接認証を求めることができるため、コンテナ内で `git pull` すると依然としてプロンプトが出ていた。

`GIT_TERMINAL_PROMPT=0` はターミナルへの認証プロンプト自体を完全に無効化する。

## Test plan

- [ ] コンテナ内で `git pull` が認証プロンプトなしで成功すること