### PR TITLE
#107 feat: Qlook update

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -1,4 +1,5 @@
 ```{include} ../README.md
+
 ```
 
 ```{toctree}

--- a/docs/total_power_flow_memo.md
+++ b/docs/total_power_flow_memo.md
@@ -1,0 +1,44 @@
+# total_power 描画フローメモ
+
+## 全体の流れ
+
+1. qlook画面の `total_power` ボタン押下
+2. フロントエンドが `role="total_power"` でトピック一覧要求
+3. サーバーが `quick_spectra` を含むトピックに絞って返却
+4. ユーザーがトピックとフィールドを選択
+5. フィールド選択でROSトピック購読開始
+6. ROSメッセージをWebSocketで `ros2-message` として受信
+7. 配列フィールドの総和を `total_power` として時系列描画
+
+## 実装ポイント（ファイル別）
+
+- ボタン定義
+  - [observer/observer/templates/qlook/index.html](observer/observer/templates/qlook/index.html#L26-L28)
+- `total_power` モードでの要求送信
+  - [observer/observer/static/index.js](observer/observer/static/index.js#L25-L31)
+- トピック一覧の絞り込み（`quick_spectra`）
+  - [observer/observer/server.py](observer/observer/server.py#L117-L127)
+- フィールド選択UIと購読トグル
+  - [observer/observer/static/quick-look.js](observer/observer/static/quick-look.js#L47-L66)
+- 購読開始要求送信
+  - [observer/observer/static/chart.js](observer/observer/static/chart.js#L56-L63)
+- ROS購読作成と `ros2-message` 配信
+  - [observer/observer/client_manager.py](observer/observer/client_manager.py#L106-L114)
+  - [observer/observer/client_manager.py](observer/observer/client_manager.py#L130-L143)
+- 総和計算と描画
+  - [observer/observer/static/chart.js](observer/observer/static/chart.js#L165-L173)
+
+## 計算式
+
+配列データを `data[field] = [x_1, x_2, ..., x_n]` とすると、描画値は
+
+$$
+\mathrm{total\_power} = \sum_{i=1}^{n} x_i
+$$
+
+です。実装では `reduce` で合計しています。
+
+## 補足
+
+- `total_power` 分岐は「配列フィールド」の場合に有効です。
+- `Graph` はID単位でインスタンスを共有するため、モード切替時のsocket扱いには注意が必要です。

--- a/observer/__init__.py
+++ b/observer/__init__.py
@@ -1,5 +1,8 @@
-from importlib.metadata import version
+from importlib.metadata import PackageNotFoundError, version
 
-__version__ = version("observer")
+try:
+    __version__ = version("observer")
+except PackageNotFoundError:
+    __version__ = "0+local"
 
-from . import address, client_manager, server  # noqa: F401
+__all__ = ["__version__"]

--- a/observer/client_manager.py
+++ b/observer/client_manager.py
@@ -5,6 +5,7 @@ import time
 import traceback
 from dataclasses import dataclass, field
 from functools import partial, wraps
+from threading import RLock
 from typing import Any, Dict, List, Optional, Tuple
 
 from flask_socketio import SocketIO
@@ -23,7 +24,7 @@ def get_msg_type(topic_name: str) -> Optional[Any]:
     info = topics.get(topic_name, None)
     if info is None:
         logger.warning(f"Message type for requested topic {topic_name!r} not found")
-        return
+        return None
     msg_type_path, *_ = info
 
     module_name, msg_name = msg_type_path.replace("/", ".").rsplit(".", 1)
@@ -37,7 +38,7 @@ def get_qos_profile(topic_name: str) -> QoSProfile:
     return qos.adaptive(topic_name, node)
 
 
-def serialize(msg: Any) -> str:
+def serialize(msg: Any) -> Dict[str, Any]:
     def get(obj: Any, key: str) -> Any:
         attr = getattr(obj, key)
         return list(attr) if isinstance(attr, (array.array, list)) else attr
@@ -73,6 +74,7 @@ class ClientManager(ServerNode):
     __clients: Dict[str, Client] = {}
     __subscribers: Dict[str, Tuple[Subscription, float]] = {}
     __socket: Optional[SocketIO] = None
+    __lock = RLock()
 
     def __new__(cls, *args, **kwargs):
         if cls._instance is None:
@@ -80,62 +82,112 @@ class ClientManager(ServerNode):
         return cls._instance
 
     def __init__(self, socket: SocketIO = None) -> None:
-        if getattr(self, "executor") is None:
+        if getattr(self, "executor", None) is None:
             super().__init__("ros2viz")
             self.start_server()
         self.__socket = socket or self.__socket
 
     @property
     def current_subscriptions(self) -> List[str]:
-        return list(self.__subscribers.keys())
+        with self.__lock:
+            return list(self.__subscribers.keys())
 
     @return_false_on_failure
     def add_client(self, sid: str) -> bool:
-        self.__clients[sid] = Client(sid)
-        logger.debug(self.__clients)
+        with self.__lock:
+            self.__clients[sid] = Client(sid)
+            logger.debug(self.__clients)
         return True
 
     @return_false_on_failure
     def remove_client(self, sid: str) -> bool:
-        for topic in self.__clients[sid].subscriptions:
+        with self.__lock:
+            client = self.__clients.get(sid)
+            topics = list(client.subscriptions) if client is not None else []
+        for topic in topics:
             self.remove_subscription(sid, topic)
-        del self.__clients[sid]
+        with self.__lock:
+            self.__clients.pop(sid, None)
         return True
 
     @return_false_on_failure
     def add_subscription(self, sid: str, topic: str) -> bool:
-        if topic not in self.current_subscriptions:
-            msgtype = get_msg_type(topic)
-            qos = get_qos_profile(topic)
-            self.__subscribers[topic] = (
-                self.create_subscription(
-                    msgtype, topic, partial(self.__emit, topic), qos
-                ),
-                time.time(),
-            )
-        self.__clients[sid].subscriptions.append(topic)
+        with self.__lock:
+            client = self.__clients.get(sid)
+            if client is None:
+                logger.warning(f"Subscription request from unknown client: {sid}")
+                return False
+            if topic in client.subscriptions:
+                return True
+            if topic in self.__subscribers:
+                client.subscriptions.append(topic)
+                return True
+
+        msgtype = get_msg_type(topic)
+        if msgtype is None:
+            return False
+        qos_profile = get_qos_profile(topic)
+
+        with self.__lock:
+            client = self.__clients.get(sid)
+            if client is None:
+                return False
+            if topic in client.subscriptions:
+                return True
+            if topic not in self.__subscribers:
+                subscription = self.create_subscription(
+                    msgtype, topic, partial(self.__emit, topic), qos_profile
+                )
+                self.__subscribers[topic] = (subscription, 0.0)
+            client.subscriptions.append(topic)
         return True
 
     @return_false_on_failure
     def remove_subscription(self, sid: str, topic: str) -> bool:
-        self.__clients[sid].subscriptions.remove(topic)
-        for client in self.__clients.values():
-            if topic in client.subscriptions:
-                return
-        logger.info(f"Destroying subscription to {topic}")
-        self.destroy_subscription(self.__subscribers[topic][0])
-        del self.__subscribers[topic]
+        with self.__lock:
+            client = self.__clients.get(sid)
+            if client is None:
+                return True
+            while topic in client.subscriptions:
+                client.subscriptions.remove(topic)
+            topic_still_used = any(
+                topic in other.subscriptions
+                for other_sid, other in self.__clients.items()
+                if other_sid != sid
+            )
+            if topic_still_used:
+                return True
+            subscription_info = self.__subscribers.get(topic)
+
+        if subscription_info is not None:
+            logger.info(f"Destroying subscription to {topic}")
+            self.destroy_subscription(subscription_info[0])
+            with self.__lock:
+                self.__subscribers.pop(topic, None)
         return True
 
     def __emit(self, topic: str, msg: Any) -> None:
-        if self.__subscribers[topic][1] > time.time() - 1 / 30:
+        now = time.time()
+        with self.__lock:
+            subscription_info = self.__subscribers.get(topic)
+            if subscription_info is None:
+                return
+            _, last_emit = subscription_info
+            if last_emit > now - 1 / 30:
+                return
+            socket = self.__socket
+            self.__subscribers[topic] = (subscription_info[0], now)
+
+        try:
+            data = serialize(msg)
+        except Exception:
+            logger.error(traceback.format_exc())
             return
 
-        data = serialize(msg)
-        if self.__socket is None:
+        if socket is None:
             logger.error(f"Socket not attached, cannot emit incoming message: {msg}")
             return
-        self.__socket.emit(
+        socket.emit(
             "ros2-message",
             {"topic_name": topic, "data": data},
             to=topic,

--- a/observer/client_manager.py
+++ b/observer/client_manager.py
@@ -6,7 +6,7 @@ import traceback
 from dataclasses import dataclass, field
 from functools import partial, wraps
 from threading import RLock
-from typing import Any, Dict, List, Optional, Tuple
+from typing import Any, Dict, List, Optional, Set
 
 from flask_socketio import SocketIO
 from necst import qos
@@ -14,7 +14,21 @@ from necst.core.server_node import ServerNode
 from rclpy.qos import QoSProfile
 from rclpy.subscription import Subscription
 
+from .stream_keys import (
+    make_stream_key,
+    normalize_fields,
+    normalize_options,
+    normalize_role_fields,
+)
+from .stream_profiles import transform_payload
+
 logger = logging.getLogger(__name__)
+
+EMIT_LIMIT_HZ = 30.0
+IDLE_TTL_SEC = 20.0
+STALE_AFTER_SEC = 5.0
+THROTTLE_AFTER_SEC = 2.0
+
 
 
 def get_msg_type(topic_name: str) -> Optional[Any]:
@@ -33,9 +47,11 @@ def get_msg_type(topic_name: str) -> Optional[Any]:
     return msg_type
 
 
+
 def get_qos_profile(topic_name: str) -> QoSProfile:
     node = ClientManager()
     return qos.adaptive(topic_name, node)
+
 
 
 def serialize(msg: Any) -> Dict[str, Any]:
@@ -44,6 +60,7 @@ def serialize(msg: Any) -> Dict[str, Any]:
         return list(attr) if isinstance(attr, (array.array, list)) else attr
 
     return {k: get(msg, k) for k in msg.get_fields_and_field_types().keys()}
+
 
 
 def return_false_on_failure(func):
@@ -59,12 +76,48 @@ def return_false_on_failure(func):
 
 
 @dataclass
+class ClientSubscription:
+    stream_key: str
+    topic: str
+    role: str = ""
+    fields: List[str] = field(default_factory=list)
+    options: Dict[str, Any] = field(default_factory=dict)
+    last_updated: float = 0.0
+
+
+@dataclass
 class Client:
     sid: str
-    subscriptions: List[str] = field(default_factory=list)
+    subscriptions: Dict[str, ClientSubscription] = field(default_factory=dict)
+    connected_at: float = field(default_factory=time.time)
+    last_activity_at: float = field(default_factory=time.time)
 
-    def subscribes_to(self, topic: str) -> bool:
-        return topic in self.subscriptions
+
+@dataclass
+class TopicState:
+    subscription: Subscription
+    stream_keys: Set[str] = field(default_factory=set)
+    client_sids: Set[str] = field(default_factory=set)
+    last_rx_time: float = 0.0
+    last_used_time: float = field(default_factory=time.time)
+    rx_count: int = 0
+
+
+@dataclass
+class StreamState:
+    stream_key: str
+    topic: str
+    role: str = ""
+    fields: List[str] = field(default_factory=list)
+    options: Dict[str, Any] = field(default_factory=dict)
+    last_emit_time: float = 0.0
+    last_rx_time: float = 0.0
+    last_used_time: float = field(default_factory=time.time)
+    rx_count: int = 0
+    emit_count: int = 0
+    throttle_count: int = 0
+    last_throttle_time: float = 0.0
+    client_sids: Set[str] = field(default_factory=set)
 
 
 class ClientManager(ServerNode):
@@ -72,7 +125,8 @@ class ClientManager(ServerNode):
     _instance = None
 
     __clients: Dict[str, Client] = {}
-    __subscribers: Dict[str, Tuple[Subscription, float]] = {}
+    __subscribers: Dict[str, TopicState] = {}
+    __streams: Dict[str, StreamState] = {}
     __socket: Optional[SocketIO] = None
     __lock = RLock()
 
@@ -90,106 +144,379 @@ class ClientManager(ServerNode):
     @property
     def current_subscriptions(self) -> List[str]:
         with self.__lock:
+            self.__cleanup_expired_subscriptions_locked(time.time())
             return list(self.__subscribers.keys())
 
     @return_false_on_failure
     def add_client(self, sid: str) -> bool:
+        now = time.time()
         with self.__lock:
-            self.__clients[sid] = Client(sid)
+            self.__cleanup_expired_subscriptions_locked(now)
+            client = self.__clients.get(sid)
+            if client is None:
+                self.__clients[sid] = Client(sid)
+            else:
+                client.last_activity_at = now
             logger.debug(self.__clients)
         return True
 
     @return_false_on_failure
     def remove_client(self, sid: str) -> bool:
+        now = time.time()
         with self.__lock:
             client = self.__clients.get(sid)
-            topics = list(client.subscriptions) if client is not None else []
-        for topic in topics:
-            self.remove_subscription(sid, topic)
+            stream_keys = list(client.subscriptions.keys()) if client is not None else []
+        for stream_key in stream_keys:
+            self.remove_subscription_by_stream_key(sid, stream_key)
         with self.__lock:
             self.__clients.pop(sid, None)
+            self.__cleanup_expired_subscriptions_locked(now)
         return True
 
-    @return_false_on_failure
-    def add_subscription(self, sid: str, topic: str) -> bool:
+    def get_client_sids(self) -> List[str]:
         with self.__lock:
+            self.__cleanup_expired_subscriptions_locked(time.time())
+            return sorted(self.__clients.keys())
+
+    @return_false_on_failure
+    def add_subscription(
+        self,
+        sid: str,
+        topic: str,
+        field_name: Optional[str] = None,
+        role: str = "",
+        options: Optional[Dict[str, Any]] = None,
+    ) -> bool:
+        now = time.time()
+        fields = normalize_role_fields(role, [field_name] if field_name else [])
+        normalized_options = normalize_options(options)
+        stream_key = make_stream_key(
+            topic,
+            role=role,
+            fields=fields,
+            options=normalized_options,
+        )
+        with self.__lock:
+            self.__cleanup_expired_subscriptions_locked(now)
             client = self.__clients.get(sid)
             if client is None:
                 logger.warning(f"Subscription request from unknown client: {sid}")
                 return False
-            if topic in client.subscriptions:
+            client.last_activity_at = now
+            existing = client.subscriptions.get(stream_key)
+            if existing is not None:
+                existing.last_updated = now
+                stream_state = self.__streams.get(stream_key)
+                if stream_state is not None:
+                    stream_state.client_sids.add(sid)
+                    stream_state.last_used_time = now
+                topic_state = self.__subscribers.get(topic)
+                if topic_state is not None:
+                    topic_state.client_sids.add(sid)
+                    topic_state.last_used_time = now
                 return True
-            if topic in self.__subscribers:
-                client.subscriptions.append(topic)
-                return True
+            topic_state = self.__subscribers.get(topic)
 
-        msgtype = get_msg_type(topic)
-        if msgtype is None:
-            return False
-        qos_profile = get_qos_profile(topic)
+        if topic_state is None:
+            msgtype = get_msg_type(topic)
+            if msgtype is None:
+                return False
+            qos_profile = get_qos_profile(topic)
+            with self.__lock:
+                if topic not in self.__subscribers:
+                    subscription = self.create_subscription(
+                        msgtype, topic, partial(self.__emit, topic), qos_profile
+                    )
+                    self.__subscribers[topic] = TopicState(subscription=subscription)
+                topic_state = self.__subscribers[topic]
+        else:
+            with self.__lock:
+                topic_state = self.__subscribers.get(topic)
 
         with self.__lock:
             client = self.__clients.get(sid)
             if client is None:
                 return False
-            if topic in client.subscriptions:
-                return True
-            if topic not in self.__subscribers:
-                subscription = self.create_subscription(
-                    msgtype, topic, partial(self.__emit, topic), qos_profile
+            client.subscriptions[stream_key] = ClientSubscription(
+                stream_key=stream_key,
+                topic=topic,
+                role=role,
+                fields=fields,
+                options=normalized_options,
+                last_updated=now,
+            )
+            stream_state = self.__streams.get(stream_key)
+            if stream_state is None:
+                stream_state = StreamState(
+                    stream_key=stream_key,
+                    topic=topic,
+                    role=role,
+                    fields=fields,
+                    options=normalized_options,
                 )
-                self.__subscribers[topic] = (subscription, 0.0)
-            client.subscriptions.append(topic)
+                self.__streams[stream_key] = stream_state
+            stream_state.client_sids.add(sid)
+            stream_state.last_used_time = now
+            topic_state = self.__subscribers.get(topic)
+            if topic_state is not None:
+                topic_state.stream_keys.add(stream_key)
+                topic_state.client_sids.add(sid)
+                topic_state.last_used_time = now
         return True
 
     @return_false_on_failure
-    def remove_subscription(self, sid: str, topic: str) -> bool:
+    def remove_subscription(
+        self,
+        sid: str,
+        topic: str,
+        field_name: Optional[str] = None,
+        role: str = "",
+        options: Optional[Dict[str, Any]] = None,
+    ) -> bool:
+        stream_key = make_stream_key(
+            topic,
+            role=role,
+            fields=normalize_role_fields(role, [field_name] if field_name else []),
+            options=normalize_options(options),
+        )
+        return self.remove_subscription_by_stream_key(sid, stream_key)
+
+    @return_false_on_failure
+    def remove_subscription_by_stream_key(self, sid: str, stream_key: str) -> bool:
+        now = time.time()
         with self.__lock:
             client = self.__clients.get(sid)
             if client is None:
                 return True
-            while topic in client.subscriptions:
-                client.subscriptions.remove(topic)
-            topic_still_used = any(
-                topic in other.subscriptions
-                for other_sid, other in self.__clients.items()
-                if other_sid != sid
-            )
-            if topic_still_used:
+            client.last_activity_at = now
+            subscription = client.subscriptions.pop(stream_key, None)
+            if subscription is None:
                 return True
-            subscription_info = self.__subscribers.get(topic)
-
-        if subscription_info is not None:
-            logger.info(f"Destroying subscription to {topic}")
-            self.destroy_subscription(subscription_info[0])
-            with self.__lock:
-                self.__subscribers.pop(topic, None)
+            stream_state = self.__streams.get(stream_key)
+            topic_state = self.__subscribers.get(subscription.topic)
+            if stream_state is not None:
+                stream_state.client_sids.discard(sid)
+                stream_state.last_used_time = now
+            if topic_state is not None:
+                topic_state.client_sids.discard(sid)
+                if any(sub.topic == subscription.topic for sub in client.subscriptions.values()):
+                    topic_state.client_sids.add(sid)
+                for candidate_sid in list(topic_state.client_sids):
+                    candidate_client = self.__clients.get(candidate_sid)
+                    if candidate_client is None:
+                        topic_state.client_sids.discard(candidate_sid)
+                        continue
+                    if any(sub.topic == subscription.topic for sub in candidate_client.subscriptions.values()):
+                        continue
+                    topic_state.client_sids.discard(candidate_sid)
+                topic_state.last_used_time = now
+            self.__cleanup_expired_subscriptions_locked(now)
         return True
+
+    def get_stream_statuses(self, stream_keys: Optional[Set[str]] = None) -> List[Dict[str, Any]]:
+        now = time.time()
+        with self.__lock:
+            self.__cleanup_expired_subscriptions_locked(now)
+            statuses: List[Dict[str, Any]] = []
+            for stream_key, state in self.__streams.items():
+                if stream_keys is not None and stream_key not in stream_keys:
+                    continue
+                last_rx_age = None if state.last_rx_time <= 0 else now - state.last_rx_time
+                last_emit_age = None if state.last_emit_time <= 0 else now - state.last_emit_time
+                last_throttle_age = None if state.last_throttle_time <= 0 else now - state.last_throttle_time
+                status = "idle"
+                if state.client_sids:
+                    status = "live"
+                    if last_rx_age is None or last_rx_age > STALE_AFTER_SEC:
+                        status = "stale"
+                    elif last_throttle_age is not None and last_throttle_age <= THROTTLE_AFTER_SEC:
+                        status = "throttled"
+                statuses.append(
+                    {
+                        "stream_key": stream_key,
+                        "topic": state.topic,
+                        "role": state.role,
+                        "fields": list(state.fields),
+                        "options": dict(state.options),
+                        "status": status,
+                        "client_count": len(state.client_sids),
+                        "server_time": now,
+                        "last_rx_time": (None if state.last_rx_time <= 0 else state.last_rx_time),
+                        "last_emit_time": (None if state.last_emit_time <= 0 else state.last_emit_time),
+                        "last_throttle_time": (None if state.last_throttle_time <= 0 else state.last_throttle_time),
+                        "last_rx_age_sec": last_rx_age,
+                        "last_emit_age_sec": last_emit_age,
+                        "last_throttle_age_sec": last_throttle_age,
+                        "rx_count": state.rx_count,
+                        "emit_count": state.emit_count,
+                        "throttle_count": state.throttle_count,
+                    }
+                )
+            statuses.sort(key=lambda item: (item["topic"], item["role"], item["fields"]))
+            return statuses
+
+    def get_status_payload_for_sid(self, sid: str) -> Dict[str, Any]:
+        with self.__lock:
+            client = self.__clients.get(sid)
+            stream_keys = set(client.subscriptions.keys()) if client is not None else set()
+        return {
+            "health": self.get_health_status(),
+            "streams": self.get_stream_statuses(stream_keys=stream_keys),
+        }
+
+    def get_session_statuses(self) -> List[Dict[str, Any]]:
+        now = time.time()
+        with self.__lock:
+            sessions: List[Dict[str, Any]] = []
+            for sid, client in self.__clients.items():
+                sessions.append(
+                    {
+                        "sid": sid,
+                        "connected_age_sec": now - client.connected_at,
+                        "last_activity_age_sec": now - client.last_activity_at,
+                        "subscriptions": {
+                            stream_key: {
+                                "topic": sub.topic,
+                                "role": sub.role,
+                                "fields": list(sub.fields),
+                                "options": dict(sub.options),
+                                "last_updated_age_sec": now - sub.last_updated if sub.last_updated else None,
+                            }
+                            for stream_key, sub in client.subscriptions.items()
+                        },
+                    }
+                )
+            sessions.sort(key=lambda item: item["sid"])
+            return sessions
+
+    def get_health_status(self) -> Dict[str, Any]:
+        now = time.time()
+        with self.__lock:
+            self.__cleanup_expired_subscriptions_locked(now)
+            return {
+                "ok": True,
+                "active_clients": len(self.__clients),
+                "active_topics": len(self.__subscribers),
+                "active_streams": len(self.__streams),
+                "idle_ttl_sec": IDLE_TTL_SEC,
+                "emit_limit_hz": EMIT_LIMIT_HZ,
+                "status_push_enabled": True,
+                "status_push_mode": "change+heartbeat",
+                "status_push_check_interval_sec": 1.0,
+                "status_push_heartbeat_sec": 10.0,
+            }
+
+    def __cleanup_expired_subscriptions_locked(self, now: float) -> None:
+        expired_stream_keys = [
+            stream_key
+            for stream_key, state in self.__streams.items()
+            if (not state.client_sids) and (now - state.last_used_time >= IDLE_TTL_SEC)
+        ]
+        for stream_key in expired_stream_keys:
+            stream_state = self.__streams.pop(stream_key, None)
+            if stream_state is None:
+                continue
+            topic_state = self.__subscribers.get(stream_state.topic)
+            if topic_state is not None:
+                topic_state.stream_keys.discard(stream_key)
+                topic_state.last_used_time = now
+
+        expired_topics = [
+            topic
+            for topic, state in self.__subscribers.items()
+            if (not state.stream_keys) and (now - state.last_used_time >= IDLE_TTL_SEC)
+        ]
+        subscriptions_to_destroy = [
+            (topic, self.__subscribers[topic].subscription) for topic in expired_topics
+        ]
+        for topic in expired_topics:
+            self.__subscribers.pop(topic, None)
+        for topic, subscription in subscriptions_to_destroy:
+            logger.info(f"Destroying idle subscription to {topic}")
+            self.destroy_subscription(subscription)
 
     def __emit(self, topic: str, msg: Any) -> None:
         now = time.time()
         with self.__lock:
-            subscription_info = self.__subscribers.get(topic)
-            if subscription_info is None:
+            topic_state = self.__subscribers.get(topic)
+            if topic_state is None:
                 return
-            _, last_emit = subscription_info
-            if last_emit > now - 1 / 30:
-                return
-            socket = self.__socket
-            self.__subscribers[topic] = (subscription_info[0], now)
+            topic_state.last_rx_time = now
+            topic_state.last_used_time = now
+            topic_state.rx_count += 1
+            stream_snapshots = []
+            for stream_key in list(topic_state.stream_keys):
+                stream_state = self.__streams.get(stream_key)
+                if stream_state is None:
+                    topic_state.stream_keys.discard(stream_key)
+                    continue
+                stream_state.last_rx_time = now
+                stream_state.last_used_time = now
+                stream_state.rx_count += 1
+                if not stream_state.client_sids:
+                    continue
+                if stream_state.last_emit_time > now - 1 / EMIT_LIMIT_HZ:
+                    stream_state.throttle_count += 1
+                    stream_state.last_throttle_time = now
+                    continue
+                stream_snapshots.append(
+                    {
+                        "stream_key": stream_key,
+                        "role": stream_state.role,
+                        "fields": list(stream_state.fields),
+                        "options": dict(stream_state.options),
+                        "sids": list(stream_state.client_sids),
+                    }
+                )
+
+        if not stream_snapshots:
+            return
 
         try:
-            data = serialize(msg)
+            raw_data = serialize(msg)
         except Exception:
             logger.error(traceback.format_exc())
             return
 
+        socket = self.__socket
         if socket is None:
             logger.error(f"Socket not attached, cannot emit incoming message: {msg}")
             return
-        socket.emit(
-            "ros2-message",
-            {"topic_name": topic, "data": data},
-            to=topic,
-            namespace="/qlook",
-        )
+
+        emitted_stream_keys: Set[str] = set()
+        for snapshot in stream_snapshots:
+            try:
+                payload = transform_payload(
+                    raw_data,
+                    role=snapshot["role"],
+                    fields=snapshot["fields"],
+                    options=snapshot["options"],
+                    fallback_time=now,
+                )
+            except Exception:
+                logger.error(traceback.format_exc())
+                continue
+            if not payload:
+                continue
+            for sid in snapshot["sids"]:
+                socket.emit(
+                    "ros2-message",
+                    {
+                        "stream_key": snapshot["stream_key"],
+                        "topic_name": topic,
+                        "data": payload,
+                        "role": snapshot["role"],
+                    },
+                    to=sid,
+                    namespace="/qlook",
+                )
+            emitted_stream_keys.add(snapshot["stream_key"])
+
+        if not emitted_stream_keys:
+            return
+        with self.__lock:
+            for stream_key in emitted_stream_keys:
+                stream_state = self.__streams.get(stream_key)
+                if stream_state is not None:
+                    stream_state.last_emit_time = now
+                    stream_state.emit_count += 1

--- a/observer/client_manager.py
+++ b/observer/client_manager.py
@@ -101,6 +101,7 @@ class TopicState:
     last_rx_time: float = 0.0
     last_used_time: float = field(default_factory=time.time)
     rx_count: int = 0
+    last_serialized_data: Optional[Dict[str, Any]] = None
 
 
 @dataclass
@@ -178,6 +179,69 @@ class ClientManager(ServerNode):
             self.__cleanup_expired_subscriptions_locked(time.time())
             return sorted(self.__clients.keys())
 
+    def __emit_payload_to_sids(
+        self,
+        *,
+        topic: str,
+        stream_key: str,
+        role: str,
+        payload: Dict[str, Any],
+        sids: List[str],
+        emitted_at: Optional[float] = None,
+    ) -> bool:
+        socket = self.__socket
+        if socket is None or not payload or not sids:
+            return False
+        for sid in sids:
+            socket.emit(
+                "ros2-message",
+                {
+                    "stream_key": stream_key,
+                    "topic_name": topic,
+                    "data": payload,
+                    "role": role,
+                },
+                to=sid,
+                namespace="/qlook",
+            )
+        if emitted_at is None:
+            emitted_at = time.time()
+        with self.__lock:
+            stream_state = self.__streams.get(stream_key)
+            if stream_state is not None:
+                stream_state.last_emit_time = emitted_at
+                stream_state.emit_count += 1
+        return True
+
+    def __emit_latest_cached_to_sid_locked(self, sid: str, stream_key: str, stream_state: "StreamState") -> bool:
+        topic_state = self.__subscribers.get(stream_state.topic)
+        if topic_state is None:
+            return False
+        raw_data = topic_state.last_serialized_data
+        if not raw_data:
+            return False
+        try:
+            payload = transform_payload(
+                raw_data,
+                role=stream_state.role,
+                fields=stream_state.fields,
+                options=stream_state.options,
+                fallback_time=topic_state.last_rx_time or time.time(),
+            )
+        except Exception:
+            logger.error(traceback.format_exc())
+            return False
+        if not payload:
+            return False
+        return self.__emit_payload_to_sids(
+            topic=stream_state.topic,
+            stream_key=stream_key,
+            role=stream_state.role,
+            payload=payload,
+            sids=[sid],
+            emitted_at=time.time(),
+        )
+
     @return_false_on_failure
     def add_subscription(
         self,
@@ -204,16 +268,26 @@ class ClientManager(ServerNode):
                 return False
             client.last_activity_at = now
             existing = client.subscriptions.get(stream_key)
+            cached_stream_state = None
             if existing is not None:
                 existing.last_updated = now
                 stream_state = self.__streams.get(stream_key)
                 if stream_state is not None:
                     stream_state.client_sids.add(sid)
                     stream_state.last_used_time = now
+                    cached_stream_state = StreamState(
+                        stream_key=stream_state.stream_key,
+                        topic=stream_state.topic,
+                        role=stream_state.role,
+                        fields=list(stream_state.fields),
+                        options=dict(stream_state.options),
+                    )
                 topic_state = self.__subscribers.get(topic)
                 if topic_state is not None:
                     topic_state.client_sids.add(sid)
                     topic_state.last_used_time = now
+                if cached_stream_state is not None:
+                    self.__emit_latest_cached_to_sid_locked(sid, stream_key, cached_stream_state)
                 return True
             topic_state = self.__subscribers.get(topic)
 
@@ -262,6 +336,14 @@ class ClientManager(ServerNode):
                 topic_state.stream_keys.add(stream_key)
                 topic_state.client_sids.add(sid)
                 topic_state.last_used_time = now
+            cached_stream_state = StreamState(
+                stream_key=stream_state.stream_key,
+                topic=stream_state.topic,
+                role=stream_state.role,
+                fields=list(stream_state.fields),
+                options=dict(stream_state.options),
+            )
+        self.__emit_latest_cached_to_sid_locked(sid, stream_key, cached_stream_state)
         return True
 
     @return_false_on_failure
@@ -478,10 +560,10 @@ class ClientManager(ServerNode):
             logger.error(traceback.format_exc())
             return
 
-        socket = self.__socket
-        if socket is None:
-            logger.error(f"Socket not attached, cannot emit incoming message: {msg}")
-            return
+        with self.__lock:
+            topic_state = self.__subscribers.get(topic)
+            if topic_state is not None:
+                topic_state.last_serialized_data = raw_data
 
         emitted_stream_keys: Set[str] = set()
         for snapshot in stream_snapshots:
@@ -498,25 +580,15 @@ class ClientManager(ServerNode):
                 continue
             if not payload:
                 continue
-            for sid in snapshot["sids"]:
-                socket.emit(
-                    "ros2-message",
-                    {
-                        "stream_key": snapshot["stream_key"],
-                        "topic_name": topic,
-                        "data": payload,
-                        "role": snapshot["role"],
-                    },
-                    to=sid,
-                    namespace="/qlook",
-                )
-            emitted_stream_keys.add(snapshot["stream_key"])
+            if self.__emit_payload_to_sids(
+                topic=topic,
+                stream_key=snapshot["stream_key"],
+                role=snapshot["role"],
+                payload=payload,
+                sids=snapshot["sids"],
+                emitted_at=now,
+            ):
+                emitted_stream_keys.add(snapshot["stream_key"])
 
         if not emitted_stream_keys:
             return
-        with self.__lock:
-            for stream_key in emitted_stream_keys:
-                stream_state = self.__streams.get(stream_key)
-                if stream_state is not None:
-                    stream_state.last_emit_time = now
-                    stream_state.emit_count += 1

--- a/observer/server.py
+++ b/observer/server.py
@@ -1,16 +1,27 @@
 import logging
 import os
+import re
 import time
 import traceback
 from pathlib import Path
-from typing import Dict
-import re
+from threading import Lock
+from typing import Any, Dict
+
 
 import neclib
 import rclpy
 import tomlkit
-from flask import Flask, Response, escape, redirect, render_template, request, url_for
-from flask_socketio import SocketIO, join_room, leave_room
+from flask import (
+    Flask,
+    Response,
+    escape,
+    jsonify,
+    redirect,
+    render_template,
+    request,
+    url_for,
+)
+from flask_socketio import SocketIO
 from neclib.core import environ
 
 from .address import get_ip_address
@@ -31,6 +42,113 @@ app = Flask(__name__)
 socketio = SocketIO(app, cors_allowed_origins="*")
 
 app.url_map.strict_slashes = False
+_status_pusher_started = False
+_status_pusher_lock = Lock()
+_status_cache_lock = Lock()
+_status_signature_by_sid: Dict[str, Any] = {}
+_status_last_sent_at_by_sid: Dict[str, float] = {}
+STATUS_PUSH_CHECK_INTERVAL_SEC = 1.0
+STATUS_PUSH_HEARTBEAT_SEC = 10.0
+
+
+def _stream_role_topics(role: str, topics):
+    if role in {"total_power", "spectrum_decimated"}:
+        topics = [topic for topic in topics if "quick_spectra" in topic[0]]
+        if not topics:
+            logger.info("There is no spectra data in ROS topics.")
+    elif role == "2d-plot":
+        topics = [topic for topic in topics if re.search("/encoder", topic[0])]
+        if not topics:
+            logger.info("There is no data that can be plotted in 2-D in ROS topics.")
+    elif role == "sis_iv":
+        topics = [topic for topic in topics if re.search("/sis_bias", topic[0])]
+        if not topics:
+            logger.info("There is no data that can be plotted in 2-D in ROS topics.")
+    return topics
+
+
+
+def build_status_signature(payload: Dict[str, Any]) -> Any:
+    health = payload.get("health") or {}
+    streams = payload.get("streams") or []
+    stream_signature = []
+    for stream in streams:
+        stream_signature.append(
+            (
+                stream.get("stream_key"),
+                stream.get("status"),
+                stream.get("client_count"),
+                tuple(stream.get("fields") or []),
+                tuple(sorted((stream.get("options") or {}).items())),
+                stream.get("role"),
+                stream.get("topic"),
+            )
+        )
+    stream_signature.sort()
+    return {
+        "health": (
+            health.get("active_clients"),
+            health.get("active_topics"),
+            health.get("active_streams"),
+            health.get("status_push_mode"),
+            health.get("status_push_heartbeat_sec"),
+        ),
+        "streams": tuple(stream_signature),
+    }
+
+
+
+def emit_status_to_sid(sid: str, *, force: bool = False) -> bool:
+    manager = ClientManager(socketio)
+    payload = manager.get_status_payload_for_sid(sid)
+    signature = build_status_signature(payload)
+    now = time.time()
+    with _status_cache_lock:
+        last_signature = _status_signature_by_sid.get(sid)
+        last_sent_at = _status_last_sent_at_by_sid.get(sid, 0.0)
+        should_emit = force or (signature != last_signature) or ((now - last_sent_at) >= STATUS_PUSH_HEARTBEAT_SEC)
+        if not should_emit:
+            return False
+        _status_signature_by_sid[sid] = signature
+        _status_last_sent_at_by_sid[sid] = now
+    socketio.emit(
+        "ros2-status",
+        payload,
+        to=sid,
+        namespace="/qlook",
+    )
+    return True
+
+
+
+def forget_status_sid(sid: str) -> None:
+    with _status_cache_lock:
+        _status_signature_by_sid.pop(sid, None)
+        _status_last_sent_at_by_sid.pop(sid, None)
+
+
+
+def status_push_loop() -> None:
+    while True:
+        socketio.sleep(STATUS_PUSH_CHECK_INTERVAL_SEC)
+        manager = ClientManager(socketio)
+        active_sids = set(manager.get_client_sids())
+        with _status_cache_lock:
+            known_sids = set(_status_signature_by_sid.keys()) | set(_status_last_sent_at_by_sid.keys())
+        for sid in sorted(known_sids - active_sids):
+            forget_status_sid(sid)
+        for sid in sorted(active_sids):
+            emit_status_to_sid(sid)
+
+
+
+def ensure_status_pusher_started() -> None:
+    global _status_pusher_started
+    with _status_pusher_lock:
+        if _status_pusher_started:
+            return
+        socketio.start_background_task(status_push_loop)
+        _status_pusher_started = True
 
 
 @app.route("/")
@@ -41,6 +159,27 @@ def index() -> Response:
 @app.route("/qlook")
 def qlook() -> str:
     return render_template("qlook/index.html")
+
+
+@app.route("/healthz")
+def healthz() -> Response:
+    return jsonify(ClientManager(socketio).get_health_status())
+
+
+@app.route("/debug/streams")
+def debug_streams() -> Response:
+    manager = ClientManager(socketio)
+    payload = manager.get_health_status()
+    payload["streams"] = manager.get_stream_statuses()
+    return jsonify(payload)
+
+
+@app.route("/debug/sessions")
+def debug_sessions() -> Response:
+    manager = ClientManager(socketio)
+    payload = manager.get_health_status()
+    payload["sessions"] = manager.get_session_statuses()
+    return jsonify(payload)
 
 
 @app.route("/config/<filename>")
@@ -98,9 +237,12 @@ def config_edit(filename: str) -> str:
 
 
 @socketio.on("connect", namespace="/qlook")
-def connect(auth) -> bool:
+def connect(auth=None) -> bool:
     logger.info(f"New Connection: {request.sid}")
+    ensure_status_pusher_started()
     success = ClientManager(socketio).add_client(request.sid)
+    if success:
+        emit_status_to_sid(request.sid, force=True)
     return success
 
 
@@ -111,6 +253,7 @@ def disconnect() -> bool:
         if ClientManager(socketio).remove_client(request.sid):
             break
         time.sleep(0.1)
+    forget_status_sid(request.sid)
     return True
 
 
@@ -119,18 +262,7 @@ def ros2_topic_list_request(json: Dict[str, str]) -> None:
     logger.info(f"Got 'ros2-topic-list-request' from {request.sid}")
     topics = ClientManager(socketio).get_topic_names_and_types()
     role = (json or {}).get("role", "")
-    if role == "total_power":
-        topics = [topic for topic in topics if "quick_spectra" in topic[0]]
-        if not topics:
-            logger.info("There is no spectra data in ROS topics.")
-    if role == "2d-plot":
-        topics = [topic for topic in topics if re.search("/encoder", topic[0])]
-        if not topics:
-            logger.info("There is no data that can be plotted in 2-D in ROS topics.")
-    if role == "sis_iv":
-        topics = [topic for topic in topics if re.search("/sis_bias", topic[0])]
-        if not topics:
-            logger.info("There is no data that can be plotted in 2-D in ROS topics.")
+    topics = _stream_role_topics(role, topics)
 
     topic_split = {}
     for topic_name, *_ in topics:
@@ -181,39 +313,84 @@ def ros2_topic_field_request(json: Dict[str, str]) -> None:
 
 
 @socketio.on("ros2-subscribe-request", namespace="/qlook")
-def ros2_subscribe_request(json: Dict[str, str]) -> None:
+def ros2_subscribe_request(json: Dict[str, Any]) -> None:
     logger.info(f"Got 'ros2-subscribe-request' from {request.sid}")
     topic_name = (json or {}).get("topic_name")
+    field_name = (json or {}).get("field_name")
+    role = (json or {}).get("role", "")
+    options = (json or {}).get("options") or {}
     success = False
     if topic_name is not None:
-        success = ClientManager(socketio).add_subscription(request.sid, topic_name)
-    if success:
-        join_room(topic_name, namespace="/qlook")
-        logger.info(f"{request.sid} joined the room {topic_name!r}")
+        success = ClientManager(socketio).add_subscription(
+            request.sid,
+            topic_name,
+            field_name=field_name,
+            role=role,
+            options=options,
+        )
     socketio.emit(
         "ros2-subscribe",
         {"success": success},
         to=request.sid,
         namespace="/qlook",
     )
+    emit_status_to_sid(request.sid, force=True)
 
 
 @socketio.on("ros2-unsubscribe-request", namespace="/qlook")
-def ros2_unsubscribe_request(json: Dict[str, str]) -> None:
+def ros2_unsubscribe_request(json: Dict[str, Any]) -> None:
     logger.info(f"Got 'ros2-unsubscribe-request' from {request.sid}")
     topic_name = (json or {}).get("topic_name")
+    field_name = (json or {}).get("field_name")
+    role = (json or {}).get("role", "")
+    options = (json or {}).get("options") or {}
+    stream_key = (json or {}).get("stream_key")
     success = False
-    if topic_name is not None:
-        success = ClientManager(socketio).remove_subscription(request.sid, topic_name)
-    if success:
-        leave_room(topic_name, namespace="/qlook")
-        logger.info(f"{request.sid} left the room {topic_name!r}")
+    if stream_key is not None:
+        success = ClientManager(socketio).remove_subscription_by_stream_key(
+            request.sid,
+            stream_key,
+        )
+    elif topic_name is not None:
+        success = ClientManager(socketio).remove_subscription(
+            request.sid,
+            topic_name,
+            field_name=field_name,
+            role=role,
+            options=options,
+        )
     socketio.emit(
         "ros2-unsubscribe",
         {"success": success},
         to=request.sid,
         namespace="/qlook",
     )
+    emit_status_to_sid(request.sid, force=True)
+
+
+@socketio.on("ros2-status-request", namespace="/qlook")
+def ros2_status_request(json: Dict[str, Any]) -> None:
+    logger.info(f"Got 'ros2-status-request' from {request.sid}")
+    topics = (json or {}).get("topics") or []
+    stream_keys = (json or {}).get("stream_keys") or []
+    manager = ClientManager(socketio)
+    streams = manager.get_stream_statuses()
+    if topics:
+        topic_set = set(topics)
+        streams = [stream for stream in streams if stream["topic"] in topic_set]
+    if stream_keys:
+        stream_key_set = set(stream_keys)
+        streams = [stream for stream in streams if stream["stream_key"] in stream_key_set]
+    socketio.emit(
+        "ros2-status",
+        {
+            "health": manager.get_health_status(),
+            "streams": streams,
+        },
+        to=request.sid,
+        namespace="/qlook",
+    )
+
 
 
 def main() -> None:

--- a/observer/server.py
+++ b/observer/server.py
@@ -118,29 +118,38 @@ def disconnect() -> bool:
 def ros2_topic_list_request(json: Dict[str, str]) -> None:
     logger.info(f"Got 'ros2-topic-list-request' from {request.sid}")
     topics = ClientManager(socketio).get_topic_names_and_types()
-    if json["role"] == "total_power":
+    role = (json or {}).get("role", "")
+    if role == "total_power":
         topics = [topic for topic in topics if "quick_spectra" in topic[0]]
         if not topics:
             logger.info("There is no spectra data in ROS topics.")
-    if json["role"] == "2d-plot":
-        topics = [
-            topic for topic in topics if re.search("/encoder", topic[0])
-        ]
+    if role == "2d-plot":
+        topics = [topic for topic in topics if re.search("/encoder", topic[0])]
         if not topics:
             logger.info("There is no data that can be plotted in 2-D in ROS topics.")
-    if json["role"] == "sis_iv":
-        topics = [
-            topic for topic in topics if re.search("/sis_bias", topic[0])
-        ]
+    if role == "sis_iv":
+        topics = [topic for topic in topics if re.search("/sis_bias", topic[0])]
         if not topics:
             logger.info("There is no data that can be plotted in 2-D in ROS topics.")
+
     topic_split = {}
-    for l in topics:
-        sp = re.split(r"(?=/)", l[0], 3)
+    for topic_name, *_ in topics:
+        sp = re.split(r"(?=/)", topic_name, 3)
         if len(sp) != 4:
-            topic_split[sp[1]] = {"system": "", "observatory": ""}
+            topic_split[topic_name] = {
+                "system": "",
+                "observatory": "",
+                "topic": topic_name,
+                "display_topic": topic_name,
+            }
         else:
-            topic_split[sp[3]] = {"system": sp[1], "observatory": sp[2]}
+            topic_split[topic_name] = {
+                "system": sp[1],
+                "observatory": sp[2],
+                "topic": sp[3],
+                "display_topic": sp[3],
+            }
+
     socketio.emit(
         "ros2-topic-list",
         {"topic_split": topic_split},
@@ -152,7 +161,7 @@ def ros2_topic_list_request(json: Dict[str, str]) -> None:
 @socketio.on("ros2-topic-field-request", namespace="/qlook")
 def ros2_topic_field_request(json: Dict[str, str]) -> None:
     logger.info(f"Got 'ros2-topic-field-request' from {request.sid}")
-    topic_info = json["topic_name"]
+    topic_info = (json or {}).get("topic_name", [])
     topic_name = "".join(topic_info)
     msg_type = get_msg_type(topic_name)
     if msg_type is None:
@@ -162,6 +171,7 @@ def ros2_topic_field_request(json: Dict[str, str]) -> None:
             to=request.sid,
             namespace="/qlook",
         )
+        return
     socketio.emit(
         "ros2-topic-field",
         {"topic_name": topic_name, "fields": msg_type.get_fields_and_field_types()},
@@ -173,23 +183,37 @@ def ros2_topic_field_request(json: Dict[str, str]) -> None:
 @socketio.on("ros2-subscribe-request", namespace="/qlook")
 def ros2_subscribe_request(json: Dict[str, str]) -> None:
     logger.info(f"Got 'ros2-subscribe-request' from {request.sid}")
-    topic_name = json["topic_name"]
-    success = ClientManager(socketio).add_subscription(request.sid, topic_name)
+    topic_name = (json or {}).get("topic_name")
+    success = False
+    if topic_name is not None:
+        success = ClientManager(socketio).add_subscription(request.sid, topic_name)
     if success:
-        join_room(topic_name)
+        join_room(topic_name, namespace="/qlook")
         logger.info(f"{request.sid} joined the room {topic_name!r}")
-    socketio.emit("ros2-subscribe", {"success": success}, to=request.sid)
+    socketio.emit(
+        "ros2-subscribe",
+        {"success": success},
+        to=request.sid,
+        namespace="/qlook",
+    )
 
 
 @socketio.on("ros2-unsubscribe-request", namespace="/qlook")
 def ros2_unsubscribe_request(json: Dict[str, str]) -> None:
     logger.info(f"Got 'ros2-unsubscribe-request' from {request.sid}")
-    topic_name = json["topic_name"]
-    success = ClientManager(socketio).remove_subscription(request.sid, topic_name)
+    topic_name = (json or {}).get("topic_name")
+    success = False
+    if topic_name is not None:
+        success = ClientManager(socketio).remove_subscription(request.sid, topic_name)
     if success:
-        leave_room(topic_name)
+        leave_room(topic_name, namespace="/qlook")
         logger.info(f"{request.sid} left the room {topic_name!r}")
-    socketio.emit("ros2-unsubscribe", {"success": success}, to=request.sid)
+    socketio.emit(
+        "ros2-unsubscribe",
+        {"success": success},
+        to=request.sid,
+        namespace="/qlook",
+    )
 
 
 def main() -> None:

--- a/observer/server.py
+++ b/observer/server.py
@@ -374,13 +374,13 @@ def ros2_status_request(json: Dict[str, Any]) -> None:
     topics = (json or {}).get("topics") or []
     stream_keys = (json or {}).get("stream_keys") or []
     manager = ClientManager(socketio)
-    streams = manager.get_stream_statuses()
-    if topics:
-        topic_set = set(topics)
-        streams = [stream for stream in streams if stream["topic"] in topic_set]
     if stream_keys:
-        stream_key_set = set(stream_keys)
-        streams = [stream for stream in streams if stream["stream_key"] in stream_key_set]
+        streams = manager.get_stream_statuses(stream_keys=set(stream_keys))
+    elif topics:
+        topic_set = set(topics)
+        streams = [stream for stream in manager.get_stream_statuses() if stream["topic"] in topic_set]
+    else:
+        streams = []
     socketio.emit(
         "ros2-status",
         {

--- a/observer/static/chart.js
+++ b/observer/static/chart.js
@@ -1,229 +1,283 @@
-"use strict"
+"use strict";
 
-import { DefaultMap } from "./utils.js"
+import { DefaultMap } from "./utils.js";
 
 class _Graph {
-    constructor(ctx, socket, config = { title: "", xLabel: "Time", yLabel: "Value" }) {
-        this.duration = 30
-        this.config = {
-            type: "line",
-            data: {
-                datasets: []
+  constructor(
+    ctx,
+    socket,
+    config = { title: "", xLabel: "Time", yLabel: "Value" },
+  ) {
+    this.duration = 30;
+    this.config = {
+      type: "line",
+      data: {
+        datasets: [],
+      },
+      options: {
+        responsive: true,
+        plugins: {
+          title: { display: true, text: config.title },
+        },
+        tooltips: { mode: "nearest", intersect: false },
+        hover: { mode: "index", intersect: true },
+        animation: { duration: 0 },
+        scales: {
+          x: {
+            type: "linear",
+            title: { display: true, text: config.xLabel },
+            min: Date.now() - this.duration * 1e3,
+            max: Date.now(),
+            ticks: {
+              minRotation: 10,
+              maxRotation: 10,
+              callback: (value, idx, ticks) => {
+                if (
+                  this.drawingArray ||
+                  this.drawingTwoFields ||
+                  this.drawingAzEl
+                ) {
+                  return value;
+                }
+                const isoString = new Date(value).toISOString();
+                if (idx === ticks.length - 1) {
+                  return isoString;
+                }
+                if (idx === 0) {
+                  return /[0-9-]*T(.*)Z/.exec(isoString)[1];
+                }
+                return /[0-9-]*T(.*).000Z/.exec(isoString)[1];
+              },
             },
-            options: {
-                responsive: true,
-                plugins: {
-                    title: { display: true, text: config.title }
-                },
-                tooltips: { mode: "nearest", intersect: false },
-                hover: { mode: "index", intersect: true },
-                animation: { duration: 0 },
-                scales: {
-                    x: {
-                        type: "linear",
-                        title: { display: true, text: config.xLabel },
-                        min: Date.now() - this.duration * 1e3,
-                        max: Date.now(),
-                        ticks: {
-                            minRotation: 10,
-                            maxRotation: 10,
-                            callback: (value, idx, ticks) => {
-                                if (this.drawingArray || this.drawingTwoFields || this.drawingAzEl) { return value }
-                                const isoString = new Date(value).toISOString()
-                                if (idx === ticks.length - 1) { return isoString }
-                                if (idx === 0) { return /[0-9-]*T(.*)Z/.exec(isoString)[1] }
-                                return /[0-9-]*T(.*).000Z/.exec(isoString)[1]
-                            }
-                        }
-                    },
-                    y: {
-                        title: { display: true, text: config.yLabel }
-                    }
-                }
+          },
+          y: {
+            title: { display: true, text: config.yLabel },
+          },
+        },
+      },
+    };
+    this.ctx = ctx;
+    this.chart = new Chart(this.ctx, this.config);
+    this.drawingArray = null;
+    this.drawingTwoFields = null;
+    this.drawingAzEl = null;
+    this.totalPowerChRange = { start: null, end: null };
+    this.updaterId = setInterval(this.#update.bind(this), 100);
+    // Without `bind`, `this` inside `this.#update` will point to `setInterval`'s.
+
+    this.subscriptions = new DefaultMap(() => []);
+    this.socket = socket;
+  }
+
+  addDataset(topic, field) {
+    const subs = this.subscriptions.get(topic);
+    if (subs.length === 0) {
+      this.socket.emit("ros2-subscribe-request", { topic_name: topic });
+    }
+    if (!subs.includes(field)) {
+      subs.push(field);
+    }
+
+    this.config.data.datasets.push({
+      label: this.#id(topic, field),
+      data: [],
+      fill: false,
+    });
+  }
+
+  removeDataset(topic, field) {
+    const subs = this.subscriptions.get(topic);
+    if (subs.includes(field)) {
+      const idx = subs.indexOf(field);
+      subs.splice(idx, 1);
+    }
+    if (subs.length === 0) {
+      this.socket.emit("ros2-unsubscribe-request", { topic_name: topic });
+      this.subscriptions.delete(topic);
+    }
+
+    const idx = this.config.data.datasets.findIndex(
+      (elem) => elem.label === this.#id(topic, field),
+    );
+    this.config.data.datasets.splice(idx, 1);
+    if (this.config.data.datasets.length === 0) {
+      this.drawingArray = null;
+    }
+  }
+
+  toggleDataset(topic, field) {
+    const idx = this.config.data.datasets.findIndex(
+      (elem) => elem.label === this.#id(topic, field),
+    );
+    if (idx !== -1) {
+      this.removeDataset(topic, field);
+    } else {
+      this.addDataset(topic, field);
+    }
+  }
+
+  #id(topic, field) {
+    return `${topic}::${field}`;
+  }
+
+  setTotalPowerChRange(start, end) {
+    const parsedStart = Number.isFinite(start) ? Math.floor(start) : null;
+    const parsedEnd = Number.isFinite(end) ? Math.floor(end) : null;
+    this.totalPowerChRange = {
+      start: parsedStart !== null && parsedStart >= 0 ? parsedStart : null,
+      end: parsedEnd !== null && parsedEnd >= 0 ? parsedEnd : null,
+    };
+  }
+
+  #update() {
+    const xScale = this.config.options.scales.x;
+    const yScale = this.config.options.scales.y;
+    if (this.drawingAzEl) {
+      xScale.min = 0;
+      xScale.max = 360;
+      yScale.min = 0;
+      yScale.max = 90; // TODO: change plot range what user want to plot
+      xScale.ticks.min = undefined;
+      xScale.ticks.max = undefined;
+      yScale.ticks.min = undefined;
+      yScale.ticks.max = undefined;
+      this.chart.update();
+    } else if (this.drawingTwoFields) {
+      xScale.min = undefined;
+      xScale.max = undefined;
+      yScale.min = undefined;
+      yScale.max = undefined;
+      xScale.ticks.min = undefined;
+      xScale.ticks.max = undefined;
+      yScale.ticks.min = undefined;
+      yScale.ticks.max = undefined;
+      this.chart.update();
+    } else if (this.drawingArray) {
+      xScale.min = 0;
+      xScale.max = undefined;
+      xScale.ticks.min = 0;
+      xScale.ticks.max = undefined;
+      this.chart.update();
+    } else {
+      const now = Date.now();
+      xScale.min = now - this.duration * 1e3;
+      xScale.max = now;
+      xScale.ticks.min = now - this.duration * 1e3;
+      xScale.ticks.max = now;
+      this.chart.update();
+    }
+  }
+
+  push(topic, data, role = "None") {
+    for (let field of this.subscriptions.get(topic)) {
+      const idx = this.config.data.datasets.findIndex(
+        (elem) => elem.label === this.#id(topic, field),
+      );
+      const dataset = this.config.data.datasets[idx];
+      const isArray = data[field].length > 1; // undefined > 1 --> false
+      if (role === "2d-plot") {
+        // HACK: Consider that unite two arguments into one.
+        this.drawingArray = false;
+        this.drawingTwoFields = false;
+        this.drawingAzEl = true;
+        const scales = this.config.options.scales;
+        dataset.data.push({ x: data["lon"], y: data["lat"] });
+        scales.x.title.text = "Azimuth [deg]";
+        scales.y.title.text = "Elevation [deg]";
+      } else if (role == "sis_iv") {
+        this.drawingArray = false;
+        this.drawingTwoFields = true;
+        this.drawingAzEl = false;
+        const scales = this.config.options.scales;
+        dataset.data.push({ x: data["voltage"], y: data["current"] });
+        scales.x.title.text = "Voltage [mV]";
+        scales.y.title.text = "Current [uA]";
+      } else if (isArray) {
+        if (role === "total_power") {
+          const values = data[field];
+          const nCh = values.length;
+          let start = this.totalPowerChRange.start ?? 0;
+          let end = this.totalPowerChRange.end ?? nCh - 1;
+          start = Math.max(0, Math.min(start, nCh - 1));
+          end = Math.max(0, Math.min(end, nCh - 1));
+          if (start > end) {
+            [start, end] = [end, start];
+          }
+
+          const total_power = values
+            .slice(start, end + 1)
+            .reduce(
+              (accumulator, currentValue) => accumulator + currentValue,
+              0,
+            );
+          this.drawingArray = false;
+          this.drawingTwoFields = false;
+          this.drawingAzEl = false;
+          try {
+            const time = data.time * 1e3 || Date.now();
+            dataset.data.push({ x: time, y: total_power });
+            const xMin = this.config.options.scales.x.min;
+            while (dataset.data[0].x < xMin) {
+              dataset.data.shift();
             }
-        }
-        this.ctx = ctx
-        this.chart = new Chart(this.ctx, this.config)
-        this.drawingArray = null
-        this.drawingTwoFields = null
-        this.drawingAzEl = null
-        this.updaterId = setInterval(this.#update.bind(this), 100)
-        // Without `bind`, `this` inside `this.#update` will point to `setInterval`'s.
-
-        this.subscriptions = new DefaultMap(() => [])
-        this.socket = socket
-    }
-
-    addDataset(topic, field) {
-        const subs = this.subscriptions.get(topic)
-        if (subs.length === 0) {
-            this.socket.emit("ros2-subscribe-request", { topic_name: topic })
-        }
-        if (!subs.includes(field)) { subs.push(field) }
-
-        this.config.data.datasets.push(
-            { label: this.#id(topic, field), data: [], fill: false }
-        )
-    }
-
-    removeDataset(topic, field) {
-        const subs = this.subscriptions.get(topic)
-        if (subs.includes(field)) {
-            const idx = subs.indexOf(field)
-            subs.splice(idx, 1)
-        }
-        if (subs.length === 0) {
-            this.socket.emit("ros2-unsubscribe-request", { topic_name: topic })
-            this.subscriptions.delete(topic)
-        }
-
-        const idx = this.config.data.datasets.findIndex(
-            (elem) => elem.label === this.#id(topic, field)
-        )
-        this.config.data.datasets.splice(idx, 1)
-        if (this.config.data.datasets.length === 0) { this.drawingArray = null }
-    }
-
-    toggleDataset(topic, field) {
-        const idx = this.config.data.datasets.findIndex(
-            (elem) => elem.label === this.#id(topic, field)
-        )
-        if (idx !== -1) {
-            this.removeDataset(topic, field)
+          } catch (error) {
+            console.debug(error);
+          }
         } else {
-            this.addDataset(topic, field)
+          this.drawingArray = true;
+          this.drawingTwoFields = false;
+          this.drawingAzEl = false;
+          dataset.data.length = 0;
+          dataset.data.push(
+            ...data[field].map((x, i) => {
+              return { x: i, y: x };
+            }),
+          );
         }
-    }
-
-    #id(topic, field) { return `${topic}::${field}` }
-
-    #update() {
-        const xScale = this.config.options.scales.x
-        const yScale = this.config.options.scales.y
-        if (this.drawingAzEl) {
-            xScale.min = 0
-            xScale.max = 360
-            yScale.min = 0
-            yScale.max = 90 // TODO: change plot range what user want to plot
-            xScale.ticks.min = undefined
-            xScale.ticks.max = undefined
-            yScale.ticks.min = undefined
-            yScale.ticks.max = undefined
-            this.chart.update()
-        } 
-        else if (this.drawingTwoFields) {
-            xScale.min = undefined
-            xScale.max = undefined
-            yScale.min = undefined
-            yScale.max = undefined
-            xScale.ticks.min = undefined
-            xScale.ticks.max = undefined
-            yScale.ticks.min = undefined
-            yScale.ticks.max = undefined
-            this.chart.update()
-        } else if (this.drawingArray) {
-            xScale.min = 0
-            xScale.max = undefined
-            xScale.ticks.min = 0
-            xScale.ticks.max = undefined
-            this.chart.update()
-        } else {
-            const now = Date.now()
-            xScale.min = now - this.duration * 1e3
-            xScale.max = now
-            xScale.ticks.min = now - this.duration * 1e3
-            xScale.ticks.max = now
-            this.chart.update()
+      } else {
+        this.drawingArray = false;
+        this.drawingTwoFields = false;
+        this.drawingAzEl = false;
+        try {
+          const time = data.time * 1e3 || Date.now();
+          dataset.data.push({ x: time, y: data[field] });
+          const xMin = this.config.options.scales.x.min;
+          while (dataset.data[0].x < xMin) {
+            dataset.data.shift();
+          }
+        } catch (error) {
+          // Catch and ignore array length change during appending the data
+          // This is caused by non-blocking `removeDataset`
+          console.debug(error);
         }
+      }
     }
+  }
 
-    push(topic, data, role = "None") {
-        for (let field of this.subscriptions.get(topic)) {
-            const idx = this.config.data.datasets.findIndex(
-                (elem) => elem.label === this.#id(topic, field)
-            )
-            const dataset = this.config.data.datasets[idx]
-            const isArray = data[field].length > 1  // undefined > 1 --> false
-            if (role === "2d-plot") {
-                // HACK: Consider that unite two arguments into one.
-                this.drawingArray = false
-                this.drawingTwoFields = false
-                this.drawingAzEl = true
-                const scales = this.config.options.scales
-                dataset.data.push({ x: data["lon"], y: data["lat"] })
-                scales.x.title.text = "Azimuth [deg]"
-                scales.y.title.text = "Elevation [deg]"
-            } else if (role == "sis_iv") {
-                this.drawingArray = false
-                this.drawingTwoFields = true
-                this.drawingAzEl = false
-                const scales = this.config.options.scales
-                dataset.data.push({ x: data["voltage"], y: data["current"] })
-                scales.x.title.text = "Voltage [mV]"
-                scales.y.title.text = "Current [uA]"
-            } else if (isArray) {
-                if (role === "total_power") {
-                    const total_power = data[field].reduce((accumulator, currentValue) => accumulator + currentValue, 0)
-                    this.drawingArray = false
-                    this.drawingTwoFields = false
-                    this.drawingAzEl = false
-                    try {
-                        const time = data.time * 1e3 || Date.now()
-                        dataset.data.push({ x: time, y: total_power })
-                        const xMin = this.config.options.scales.x.min
-                        while (dataset.data[0].x < xMin) { dataset.data.shift() }
-                    } catch (error) {
-                        console.debug(error)
-                    }
-                } else {
-                    this.drawingArray = true
-                    this.drawingTwoFields = false
-                    this.drawingAzEl = false
-                    dataset.data.length = 0
-                    dataset.data.push(...data[field].map((x, i) => { return { x: i, y: x } }))
-                }
-            } else {
-                this.drawingArray = false
-                this.drawingTwoFields = false
-                this.drawingAzEl = false
-                try {
-                    const time = data.time * 1e3 || Date.now()
-                    dataset.data.push({ x: time, y: data[field] })
-                    const xMin = this.config.options.scales.x.min
-                    while (dataset.data[0].x < xMin) { dataset.data.shift() }
-                } catch (error) {
-                    // Catch and ignore array length change during appending the data
-                    // This is caused by non-blocking `removeDataset`
-                    console.debug(error)
-                }
-            }
-        }
-    }
+  destroy() {
+    this.clear();
+    clearInterval(this.updaterId);
+    this.chart.destroy();
+  }
 
-    destroy() {
-        this.clear()
-        clearInterval(this.updaterId)
-        this.chart.destroy()
+  clear() {
+    for (let [topic, fields] of this.subscriptions) {
+      for (let field of fields) {
+        this.removeDataset(topic, field);
+      }
     }
-
-    clear() {
-        for (let [topic, fields] of this.subscriptions) {
-            for (let field of fields) {
-                this.removeDataset(topic, field)
-            }
-        }
-    }
+  }
 }
 
-const GraphInstances = new Map()
+const GraphInstances = new Map();
 
 const Graph = (id, socket, config) => {
-    if (!GraphInstances.has(id)) {
-        const _ctx = $(`#${id.replace(/^#/, '')}`)
-        const ctx = _ctx[0].getContext("2d")
-        GraphInstances.set(id, new _Graph(ctx, socket, config))
-    }
-    return GraphInstances.get(id)
-}
+  if (!GraphInstances.has(id)) {
+    const _ctx = $(`#${id.replace(/^#/, "")}`);
+    const ctx = _ctx[0].getContext("2d");
+    GraphInstances.set(id, new _Graph(ctx, socket, config));
+  }
+  return GraphInstances.get(id);
+};
 
-export { Graph }
+export { Graph };

--- a/observer/static/chart.js
+++ b/observer/static/chart.js
@@ -1,283 +1,243 @@
-"use strict";
+"use strict"
 
-import { DefaultMap } from "./utils.js";
+import { DefaultMap } from "./utils.js"
 
 class _Graph {
-  constructor(
-    ctx,
-    socket,
-    config = { title: "", xLabel: "Time", yLabel: "Value" },
-  ) {
-    this.duration = 30;
-    this.config = {
-      type: "line",
-      data: {
-        datasets: [],
-      },
-      options: {
-        responsive: true,
-        plugins: {
-          title: { display: true, text: config.title },
-        },
-        tooltips: { mode: "nearest", intersect: false },
-        hover: { mode: "index", intersect: true },
-        animation: { duration: 0 },
-        scales: {
-          x: {
-            type: "linear",
-            title: { display: true, text: config.xLabel },
-            min: Date.now() - this.duration * 1e3,
-            max: Date.now(),
-            ticks: {
-              minRotation: 10,
-              maxRotation: 10,
-              callback: (value, idx, ticks) => {
-                if (
-                  this.drawingArray ||
-                  this.drawingTwoFields ||
-                  this.drawingAzEl
-                ) {
-                  return value;
-                }
-                const isoString = new Date(value).toISOString();
-                if (idx === ticks.length - 1) {
-                  return isoString;
-                }
-                if (idx === 0) {
-                  return /[0-9-]*T(.*)Z/.exec(isoString)[1];
-                }
-                return /[0-9-]*T(.*).000Z/.exec(isoString)[1];
-              },
+    constructor(ctx, socket, config = { title: "", xLabel: "Time", yLabel: "Value" }) {
+        this.duration = 30
+        this.config = {
+            type: "line",
+            data: {
+                datasets: []
             },
-          },
-          y: {
-            title: { display: true, text: config.yLabel },
-          },
-        },
-      },
-    };
-    this.ctx = ctx;
-    this.chart = new Chart(this.ctx, this.config);
-    this.drawingArray = null;
-    this.drawingTwoFields = null;
-    this.drawingAzEl = null;
-    this.totalPowerChRange = { start: null, end: null };
-    this.updaterId = setInterval(this.#update.bind(this), 100);
-    // Without `bind`, `this` inside `this.#update` will point to `setInterval`'s.
-
-    this.subscriptions = new DefaultMap(() => []);
-    this.socket = socket;
-  }
-
-  addDataset(topic, field) {
-    const subs = this.subscriptions.get(topic);
-    if (subs.length === 0) {
-      this.socket.emit("ros2-subscribe-request", { topic_name: topic });
-    }
-    if (!subs.includes(field)) {
-      subs.push(field);
-    }
-
-    this.config.data.datasets.push({
-      label: this.#id(topic, field),
-      data: [],
-      fill: false,
-    });
-  }
-
-  removeDataset(topic, field) {
-    const subs = this.subscriptions.get(topic);
-    if (subs.includes(field)) {
-      const idx = subs.indexOf(field);
-      subs.splice(idx, 1);
-    }
-    if (subs.length === 0) {
-      this.socket.emit("ros2-unsubscribe-request", { topic_name: topic });
-      this.subscriptions.delete(topic);
-    }
-
-    const idx = this.config.data.datasets.findIndex(
-      (elem) => elem.label === this.#id(topic, field),
-    );
-    this.config.data.datasets.splice(idx, 1);
-    if (this.config.data.datasets.length === 0) {
-      this.drawingArray = null;
-    }
-  }
-
-  toggleDataset(topic, field) {
-    const idx = this.config.data.datasets.findIndex(
-      (elem) => elem.label === this.#id(topic, field),
-    );
-    if (idx !== -1) {
-      this.removeDataset(topic, field);
-    } else {
-      this.addDataset(topic, field);
-    }
-  }
-
-  #id(topic, field) {
-    return `${topic}::${field}`;
-  }
-
-  setTotalPowerChRange(start, end) {
-    const parsedStart = Number.isFinite(start) ? Math.floor(start) : null;
-    const parsedEnd = Number.isFinite(end) ? Math.floor(end) : null;
-    this.totalPowerChRange = {
-      start: parsedStart !== null && parsedStart >= 0 ? parsedStart : null,
-      end: parsedEnd !== null && parsedEnd >= 0 ? parsedEnd : null,
-    };
-  }
-
-  #update() {
-    const xScale = this.config.options.scales.x;
-    const yScale = this.config.options.scales.y;
-    if (this.drawingAzEl) {
-      xScale.min = 0;
-      xScale.max = 360;
-      yScale.min = 0;
-      yScale.max = 90; // TODO: change plot range what user want to plot
-      xScale.ticks.min = undefined;
-      xScale.ticks.max = undefined;
-      yScale.ticks.min = undefined;
-      yScale.ticks.max = undefined;
-      this.chart.update();
-    } else if (this.drawingTwoFields) {
-      xScale.min = undefined;
-      xScale.max = undefined;
-      yScale.min = undefined;
-      yScale.max = undefined;
-      xScale.ticks.min = undefined;
-      xScale.ticks.max = undefined;
-      yScale.ticks.min = undefined;
-      yScale.ticks.max = undefined;
-      this.chart.update();
-    } else if (this.drawingArray) {
-      xScale.min = 0;
-      xScale.max = undefined;
-      xScale.ticks.min = 0;
-      xScale.ticks.max = undefined;
-      this.chart.update();
-    } else {
-      const now = Date.now();
-      xScale.min = now - this.duration * 1e3;
-      xScale.max = now;
-      xScale.ticks.min = now - this.duration * 1e3;
-      xScale.ticks.max = now;
-      this.chart.update();
-    }
-  }
-
-  push(topic, data, role = "None") {
-    for (let field of this.subscriptions.get(topic)) {
-      const idx = this.config.data.datasets.findIndex(
-        (elem) => elem.label === this.#id(topic, field),
-      );
-      const dataset = this.config.data.datasets[idx];
-      const isArray = data[field].length > 1; // undefined > 1 --> false
-      if (role === "2d-plot") {
-        // HACK: Consider that unite two arguments into one.
-        this.drawingArray = false;
-        this.drawingTwoFields = false;
-        this.drawingAzEl = true;
-        const scales = this.config.options.scales;
-        dataset.data.push({ x: data["lon"], y: data["lat"] });
-        scales.x.title.text = "Azimuth [deg]";
-        scales.y.title.text = "Elevation [deg]";
-      } else if (role == "sis_iv") {
-        this.drawingArray = false;
-        this.drawingTwoFields = true;
-        this.drawingAzEl = false;
-        const scales = this.config.options.scales;
-        dataset.data.push({ x: data["voltage"], y: data["current"] });
-        scales.x.title.text = "Voltage [mV]";
-        scales.y.title.text = "Current [uA]";
-      } else if (isArray) {
-        if (role === "total_power") {
-          const values = data[field];
-          const nCh = values.length;
-          let start = this.totalPowerChRange.start ?? 0;
-          let end = this.totalPowerChRange.end ?? nCh - 1;
-          start = Math.max(0, Math.min(start, nCh - 1));
-          end = Math.max(0, Math.min(end, nCh - 1));
-          if (start > end) {
-            [start, end] = [end, start];
-          }
-
-          const total_power = values
-            .slice(start, end + 1)
-            .reduce(
-              (accumulator, currentValue) => accumulator + currentValue,
-              0,
-            );
-          this.drawingArray = false;
-          this.drawingTwoFields = false;
-          this.drawingAzEl = false;
-          try {
-            const time = data.time * 1e3 || Date.now();
-            dataset.data.push({ x: time, y: total_power });
-            const xMin = this.config.options.scales.x.min;
-            while (dataset.data[0].x < xMin) {
-              dataset.data.shift();
+            options: {
+                responsive: true,
+                plugins: {
+                    title: { display: true, text: config.title }
+                },
+                tooltips: { mode: "nearest", intersect: false },
+                hover: { mode: "index", intersect: true },
+                animation: { duration: 0 },
+                scales: {
+                    x: {
+                        type: "linear",
+                        title: { display: true, text: config.xLabel },
+                        min: Date.now() - this.duration * 1e3,
+                        max: Date.now(),
+                        ticks: {
+                            minRotation: 10,
+                            maxRotation: 10,
+                            callback: (value, idx, ticks) => {
+                                if (this.drawingArray || this.drawingTwoFields || this.drawingAzEl) { return value }
+                                const isoString = new Date(value).toISOString()
+                                if (idx === ticks.length - 1) { return isoString }
+                                if (idx === 0) { return /[0-9-]*T(.*)Z/.exec(isoString)[1] }
+                                return /[0-9-]*T(.*).000Z/.exec(isoString)[1]
+                            }
+                        }
+                    },
+                    y: {
+                        title: { display: true, text: config.yLabel }
+                    }
+                }
             }
-          } catch (error) {
-            console.debug(error);
-          }
+        }
+        this.ctx = ctx
+        this.chart = new Chart(this.ctx, this.config)
+        this.drawingArray = null
+        this.drawingTwoFields = null
+        this.drawingAzEl = null
+        this.updaterId = setInterval(this.#update.bind(this), 100)
+
+        this.subscriptions = new DefaultMap(() => [])
+        this.socket = socket
+    }
+
+    addDataset(topic, field) {
+        const subs = this.subscriptions.get(topic)
+        if (subs.length === 0) {
+            this.socket.emit("ros2-subscribe-request", { topic_name: topic })
+        }
+        if (!subs.includes(field)) {
+            subs.push(field)
+            this.config.data.datasets.push(
+                { label: this.#id(topic, field), data: [], fill: false }
+            )
+        }
+    }
+
+    removeDataset(topic, field) {
+        const subs = this.subscriptions.get(topic)
+        if (subs.includes(field)) {
+            const idx = subs.indexOf(field)
+            subs.splice(idx, 1)
+        }
+        if (subs.length === 0) {
+            this.socket.emit("ros2-unsubscribe-request", { topic_name: topic })
+            this.subscriptions.delete(topic)
+        }
+
+        const idx = this.config.data.datasets.findIndex(
+            (elem) => elem.label === this.#id(topic, field)
+        )
+        if (idx !== -1) {
+            this.config.data.datasets.splice(idx, 1)
+        }
+        if (this.config.data.datasets.length === 0) {
+            this.drawingArray = null
+            this.drawingTwoFields = null
+            this.drawingAzEl = null
+        }
+    }
+
+    toggleDataset(topic, field) {
+        const idx = this.config.data.datasets.findIndex(
+            (elem) => elem.label === this.#id(topic, field)
+        )
+        if (idx !== -1) {
+            this.removeDataset(topic, field)
         } else {
-          this.drawingArray = true;
-          this.drawingTwoFields = false;
-          this.drawingAzEl = false;
-          dataset.data.length = 0;
-          dataset.data.push(
-            ...data[field].map((x, i) => {
-              return { x: i, y: x };
-            }),
-          );
+            this.addDataset(topic, field)
         }
-      } else {
-        this.drawingArray = false;
-        this.drawingTwoFields = false;
-        this.drawingAzEl = false;
-        try {
-          const time = data.time * 1e3 || Date.now();
-          dataset.data.push({ x: time, y: data[field] });
-          const xMin = this.config.options.scales.x.min;
-          while (dataset.data[0].x < xMin) {
-            dataset.data.shift();
-          }
-        } catch (error) {
-          // Catch and ignore array length change during appending the data
-          // This is caused by non-blocking `removeDataset`
-          console.debug(error);
+    }
+
+    #id(topic, field) { return `${topic}::${field}` }
+
+    #update() {
+        const xScale = this.config.options.scales.x
+        const yScale = this.config.options.scales.y
+        if (this.drawingAzEl) {
+            xScale.min = 0
+            xScale.max = 360
+            yScale.min = 0
+            yScale.max = 90
+            xScale.ticks.min = undefined
+            xScale.ticks.max = undefined
+            yScale.ticks.min = undefined
+            yScale.ticks.max = undefined
+            this.chart.update()
         }
-      }
+        else if (this.drawingTwoFields) {
+            xScale.min = undefined
+            xScale.max = undefined
+            yScale.min = undefined
+            yScale.max = undefined
+            xScale.ticks.min = undefined
+            xScale.ticks.max = undefined
+            yScale.ticks.min = undefined
+            yScale.ticks.max = undefined
+            this.chart.update()
+        } else if (this.drawingArray) {
+            xScale.min = 0
+            xScale.max = undefined
+            xScale.ticks.min = 0
+            xScale.ticks.max = undefined
+            this.chart.update()
+        } else {
+            const now = Date.now()
+            xScale.min = now - this.duration * 1e3
+            xScale.max = now
+            xScale.ticks.min = now - this.duration * 1e3
+            xScale.ticks.max = now
+            this.chart.update()
+        }
     }
-  }
 
-  destroy() {
-    this.clear();
-    clearInterval(this.updaterId);
-    this.chart.destroy();
-  }
-
-  clear() {
-    for (let [topic, fields] of this.subscriptions) {
-      for (let field of fields) {
-        this.removeDataset(topic, field);
-      }
+    push(topic, data, role = "None") {
+        const fields = [...this.subscriptions.get(topic)]
+        for (let field of fields) {
+            if (!(field in data)) { continue }
+            const idx = this.config.data.datasets.findIndex(
+                (elem) => elem.label === this.#id(topic, field)
+            )
+            if (idx === -1) { continue }
+            const dataset = this.config.data.datasets[idx]
+            if (!dataset) { continue }
+            const value = data[field]
+            const isArray = Array.isArray(value) ? value.length > 1 : false
+            if (role === "2d-plot") {
+                this.drawingArray = false
+                this.drawingTwoFields = false
+                this.drawingAzEl = true
+                const scales = this.config.options.scales
+                if (("lon" in data) && ("lat" in data)) {
+                    dataset.data.push({ x: data["lon"], y: data["lat"] })
+                }
+                scales.x.title.text = "Azimuth [deg]"
+                scales.y.title.text = "Elevation [deg]"
+            } else if (role == "sis_iv") {
+                this.drawingArray = false
+                this.drawingTwoFields = true
+                this.drawingAzEl = false
+                const scales = this.config.options.scales
+                if (("voltage" in data) && ("current" in data)) {
+                    dataset.data.push({ x: data["voltage"], y: data["current"] })
+                }
+                scales.x.title.text = "Voltage [mV]"
+                scales.y.title.text = "Current [uA]"
+            } else if (isArray) {
+                if (role === "total_power") {
+                    const total_power = value.reduce((accumulator, currentValue) => accumulator + currentValue, 0)
+                    this.drawingArray = false
+                    this.drawingTwoFields = false
+                    this.drawingAzEl = false
+                    try {
+                        const time = data.time * 1e3 || Date.now()
+                        dataset.data.push({ x: time, y: total_power })
+                        const xMin = this.config.options.scales.x.min
+                        while ((dataset.data.length > 0) && (dataset.data[0].x < xMin)) { dataset.data.shift() }
+                    } catch (error) {
+                        console.debug(error)
+                    }
+                } else {
+                    this.drawingArray = true
+                    this.drawingTwoFields = false
+                    this.drawingAzEl = false
+                    dataset.data.length = 0
+                    dataset.data.push(...value.map((x, i) => { return { x: i, y: x } }))
+                }
+            } else {
+                this.drawingArray = false
+                this.drawingTwoFields = false
+                this.drawingAzEl = false
+                try {
+                    const time = data.time * 1e3 || Date.now()
+                    dataset.data.push({ x: time, y: value })
+                    const xMin = this.config.options.scales.x.min
+                    while ((dataset.data.length > 0) && (dataset.data[0].x < xMin)) { dataset.data.shift() }
+                } catch (error) {
+                    console.debug(error)
+                }
+            }
+        }
     }
-  }
+
+    destroy() {
+        this.clear()
+        clearInterval(this.updaterId)
+        this.chart.destroy()
+    }
+
+    clear() {
+        for (let [topic, fields] of Array.from(this.subscriptions.entries())) {
+            for (let field of [...fields]) {
+                this.removeDataset(topic, field)
+            }
+        }
+    }
 }
 
-const GraphInstances = new Map();
+const GraphInstances = new Map()
 
 const Graph = (id, socket, config) => {
-  if (!GraphInstances.has(id)) {
-    const _ctx = $(`#${id.replace(/^#/, "")}`);
-    const ctx = _ctx[0].getContext("2d");
-    GraphInstances.set(id, new _Graph(ctx, socket, config));
-  }
-  return GraphInstances.get(id);
-};
+    if (!GraphInstances.has(id)) {
+        const _ctx = $(`#${id.replace(/^#/, '')}`)
+        const ctx = _ctx[0].getContext("2d")
+        GraphInstances.set(id, new _Graph(ctx, socket, config))
+    } else if (socket) {
+        GraphInstances.get(id).socket = socket
+    }
+    return GraphInstances.get(id)
+}
 
-export { Graph };
+export { Graph }

--- a/observer/static/chart.js
+++ b/observer/static/chart.js
@@ -1,87 +1,251 @@
 "use strict"
 
-import { DefaultMap } from "./utils.js"
+const MAX_AZEL_POINTS = 10000
+const MAX_SIS_IV_POINTS = 5000
+
+const defaultConfig = {
+    type: 'line',
+    data: { datasets: [] },
+    options: {
+        animation: false,
+        scales: {
+            x: {
+                type: 'linear',
+                ticks: {
+                    minRotation: 10,
+                    maxRotation: 10,
+                    callback: function (value, idx, ticks) {
+                        const graph = this?.chart?.$graphInstance
+                        if (graph?.drawingArray || graph?.drawingTwoFields || graph?.drawingAzEl) {
+                            return value
+                        }
+                        const isoString = new Date(value).toISOString()
+                        if (idx === ticks.length - 1) { return isoString }
+                        if (idx === 0) { return /[0-9-]*T(.*)Z/.exec(isoString)?.[1] || isoString }
+                        return /[0-9-]*T(.*).000Z/.exec(isoString)?.[1] || isoString
+                    },
+                },
+            },
+            y: {},
+        }
+    }
+}
 
 class _Graph {
-    constructor(ctx, socket, config = { title: "", xLabel: "Time", yLabel: "Value" }) {
-        this.duration = 30
-        this.config = {
-            type: "line",
-            data: {
-                datasets: []
-            },
-            options: {
-                responsive: true,
-                plugins: {
-                    title: { display: true, text: config.title }
-                },
-                tooltips: { mode: "nearest", intersect: false },
-                hover: { mode: "index", intersect: true },
-                animation: { duration: 0 },
-                scales: {
-                    x: {
-                        type: "linear",
-                        title: { display: true, text: config.xLabel },
-                        min: Date.now() - this.duration * 1e3,
-                        max: Date.now(),
-                        ticks: {
-                            minRotation: 10,
-                            maxRotation: 10,
-                            callback: (value, idx, ticks) => {
-                                if (this.drawingArray || this.drawingTwoFields || this.drawingAzEl) { return value }
-                                const isoString = new Date(value).toISOString()
-                                if (idx === ticks.length - 1) { return isoString }
-                                if (idx === 0) { return /[0-9-]*T(.*)Z/.exec(isoString)[1] }
-                                return /[0-9-]*T(.*).000Z/.exec(isoString)[1]
-                            }
-                        }
-                    },
-                    y: {
-                        title: { display: true, text: config.yLabel }
-                    }
-                }
-            }
-        }
-        this.ctx = ctx
-        this.chart = new Chart(this.ctx, this.config)
-        this.drawingArray = null
-        this.drawingTwoFields = null
-        this.drawingAzEl = null
-        this.updaterId = setInterval(this.#update.bind(this), 100)
 
-        this.subscriptions = new DefaultMap(() => [])
+    updaterId
+    chart
+    subscriptions = new Map()
+    drawingArray = null
+    drawingTwoFields = null
+    drawingAzEl = null
+    activeRole = ""
+    roleOptions = new Map()
+
+    constructor(ctx, socket, config = {}) {
+        this.config = $.extend(true, {}, defaultConfig, config)
+        this.chart = new Chart(ctx, this.config)
+        this.chart.$graphInstance = this
+        this.updaterId = setInterval(() => this.#update(), 200)
+        this.duration = 60
         this.socket = socket
     }
 
-    addDataset(topic, field) {
-        const subs = this.subscriptions.get(topic)
-        if (subs.length === 0) {
-            this.socket.emit("ros2-subscribe-request", { topic_name: topic })
-        }
-        if (!subs.includes(field)) {
-            subs.push(field)
-            this.config.data.datasets.push(
-                { label: this.#id(topic, field), data: [], fill: false }
-            )
+    setRole(role = "", options = null) {
+        this.activeRole = role || ""
+        if (options != null) {
+            this.setRoleOptions(this.activeRole, options)
         }
     }
 
-    removeDataset(topic, field) {
-        const subs = this.subscriptions.get(topic)
-        if (subs.includes(field)) {
-            const idx = subs.indexOf(field)
-            subs.splice(idx, 1)
+    setRoleOptions(role = "", options = {}) {
+        this.roleOptions.set(role || "", this.normalizeOptions(options))
+    }
+
+    getRoleOptions(role = this.activeRole) {
+        return { ...(this.roleOptions.get(role || "") || {}) }
+    }
+
+    updateCurrentRoleOptions(options = {}) {
+        const role = this.activeRole || ""
+        const normalized = this.normalizeOptions(options)
+        this.setRoleOptions(role, normalized)
+        const entries = Array.from(this.subscriptions.values()).filter((entry) => (entry.role || "") === role)
+        for (let entry of entries) {
+            const existingData = this.findDataset(entry.streamKey)?.data || []
+            this.removeDataset(entry.topic, entry.field, entry.role, entry.options)
+            this.addDataset(entry.topic, entry.field, entry.role, normalized)
+            const dataset = this.findDataset(this.streamKey(entry.topic, entry.field, entry.role, normalized))
+            if (dataset) {
+                dataset.data = existingData.slice(-Math.min(existingData.length, 256))
+            }
         }
-        if (subs.length === 0) {
-            this.socket.emit("ros2-unsubscribe-request", { topic_name: topic })
-            this.subscriptions.delete(topic)
+    }
+
+    normalizeRoleFields(role = this.activeRole, field = "") {
+        const effectiveRole = role || ""
+        return (["", "total_power", "spectrum_decimated"].includes(effectiveRole) && field) ? [field] : []
+    }
+
+    normalizeOptions(options = {}) {
+        const normalized = {}
+        for (let key of Object.keys(options || {}).sort()) {
+            const value = options[key]
+            if (value === undefined || value === null || value === "") {
+                continue
+            }
+            normalized[key] = value
         }
+        return normalized
+    }
+
+    streamKey(topic, field, role = this.activeRole, options = null) {
+        const normalizedOptions = this.normalizeOptions(options == null ? this.getRoleOptions(role) : options)
+        return JSON.stringify({
+            fields: this.normalizeRoleFields(role, field),
+            options: normalizedOptions,
+            role: role || "",
+            topic,
+        })
+    }
+
+    datasetLabel(topic, field, role = this.activeRole, options = null) {
+        const effectiveField = (["", "total_power", "spectrum_decimated"].includes(role || "")) ? field : (role === "2d-plot" ? "path" : (role === "sis_iv" ? "curve" : field))
+        const suffix = role ? ` [${role}]` : ""
+        const normalizedOptions = this.normalizeOptions(options == null ? this.getRoleOptions(role) : options)
+        const optionParts = []
+        if (role === "spectrum_decimated" && normalizedOptions.max_points) {
+            optionParts.push(`max_points=${normalizedOptions.max_points}`)
+        }
+        if (["total_power", "spectrum_decimated"].includes(role || "")) {
+            const start = normalizedOptions.channel_start
+            const stop = normalizedOptions.channel_stop
+            if (start !== undefined || stop !== undefined) {
+                optionParts.push(`channels=${start ?? 0}:${stop ?? 'end'}`)
+            }
+        }
+        const optionSuffix = optionParts.length ? ` (${optionParts.join(", ")})` : ""
+        return `${topic}::${effectiveField}${suffix}${optionSuffix}`
+    }
+
+    findDataset(streamKey) {
+        return this.config.data.datasets.find((elem) => elem.streamKey === streamKey)
+    }
+
+    describeStream(streamKey) {
+        const entry = this.subscriptions.get(streamKey)
+        if (!entry) {
+            const dataset = this.findDataset(streamKey)
+            if (dataset) {
+                return {
+                    topic: dataset.topic,
+                    field: dataset.field,
+                    role: dataset.role,
+                    options: { ...(dataset.options || {}) },
+                    label: dataset.label,
+                }
+            }
+            return { label: streamKey }
+        }
+        return {
+            topic: entry.topic,
+            field: entry.field,
+            role: entry.role,
+            options: { ...(entry.options || {}) },
+            label: this.datasetLabel(entry.topic, entry.field, entry.role, entry.options),
+        }
+    }
+
+    getSubscriptionsSnapshot() {
+        return {
+            role: this.activeRole,
+            roleOptions: Object.fromEntries(this.roleOptions.entries()),
+            subscriptions: Array.from(this.subscriptions.values()).map((entry) => {
+                return {
+                    stream_key: entry.streamKey,
+                    topic: entry.topic,
+                    field: entry.field,
+                    role: entry.role,
+                    options: { ...(entry.options || {}) },
+                }
+            }),
+        }
+    }
+
+    restoreSubscriptions(snapshot = null) {
+        const state = snapshot || this.getSubscriptionsSnapshot()
+        const roleOptions = state.roleOptions || {}
+        for (let role of Object.keys(roleOptions)) {
+            this.setRoleOptions(role, roleOptions[role])
+        }
+        this.setRole(state.role || this.activeRole)
+        for (let entry of (state.subscriptions || [])) {
+            this.socket.emit("ros2-subscribe-request", {
+                topic_name: entry.topic,
+                field_name: entry.field,
+                role: entry.role || "",
+                options: entry.options || {},
+            })
+        }
+    }
+
+    listStreamKeys() {
+        return Array.from(this.subscriptions.keys())
+    }
+
+    addDataset(topic, field, role = this.activeRole, options = null) {
+        const effectiveOptions = this.normalizeOptions(options == null ? this.getRoleOptions(role) : options)
+        const streamKey = this.streamKey(topic, field, role, effectiveOptions)
+        if (!this.subscriptions.has(streamKey)) {
+            this.subscriptions.set(streamKey, {
+                streamKey,
+                topic,
+                field,
+                role: role || "",
+                options: effectiveOptions,
+            })
+            this.config.data.datasets.push(
+                {
+                    label: this.datasetLabel(topic, field, role, effectiveOptions),
+                    data: [],
+                    fill: false,
+                    streamKey,
+                    topic,
+                    field,
+                    role,
+                    options: effectiveOptions,
+                }
+            )
+        }
+        this.socket.emit("ros2-subscribe-request", {
+            topic_name: topic,
+            field_name: field,
+            role: role || "",
+            options: effectiveOptions,
+        })
+    }
+
+    removeDataset(topic, field, role = this.activeRole, options = null, { keepVisualData = false } = {}) {
+        const effectiveOptions = this.normalizeOptions(options == null ? this.getRoleOptions(role) : options)
+        const streamKey = this.streamKey(topic, field, role, effectiveOptions)
+        this.socket.emit("ros2-unsubscribe-request", {
+            topic_name: topic,
+            field_name: field,
+            role: role || "",
+            options: effectiveOptions,
+            stream_key: streamKey,
+        })
+        this.subscriptions.delete(streamKey)
 
         const idx = this.config.data.datasets.findIndex(
-            (elem) => elem.label === this.#id(topic, field)
+            (elem) => elem.streamKey === streamKey
         )
         if (idx !== -1) {
-            this.config.data.datasets.splice(idx, 1)
+            if (keepVisualData) {
+                this.config.data.datasets[idx].streamKey = `stale:${streamKey}`
+            } else {
+                this.config.data.datasets.splice(idx, 1)
+            }
         }
         if (this.config.data.datasets.length === 0) {
             this.drawingArray = null
@@ -90,18 +254,15 @@ class _Graph {
         }
     }
 
-    toggleDataset(topic, field) {
-        const idx = this.config.data.datasets.findIndex(
-            (elem) => elem.label === this.#id(topic, field)
-        )
-        if (idx !== -1) {
-            this.removeDataset(topic, field)
+    toggleDataset(topic, field, role = this.activeRole, options = null) {
+        const effectiveOptions = this.normalizeOptions(options == null ? this.getRoleOptions(role) : options)
+        const streamKey = this.streamKey(topic, field, role, effectiveOptions)
+        if (this.subscriptions.has(streamKey)) {
+            this.removeDataset(topic, field, role, effectiveOptions)
         } else {
-            this.addDataset(topic, field)
+            this.addDataset(topic, field, role, effectiveOptions)
         }
     }
-
-    #id(topic, field) { return `${topic}::${field}` }
 
     #update() {
         const xScale = this.config.options.scales.x
@@ -128,9 +289,9 @@ class _Graph {
             yScale.ticks.max = undefined
             this.chart.update()
         } else if (this.drawingArray) {
-            xScale.min = 0
+            xScale.min = undefined
             xScale.max = undefined
-            xScale.ticks.min = 0
+            xScale.ticks.min = undefined
             xScale.ticks.max = undefined
             this.chart.update()
         } else {
@@ -143,71 +304,65 @@ class _Graph {
         }
     }
 
-    push(topic, data, role = "None") {
-        const fields = [...this.subscriptions.get(topic)]
-        for (let field of fields) {
-            if (!(field in data)) { continue }
-            const idx = this.config.data.datasets.findIndex(
-                (elem) => elem.label === this.#id(topic, field)
-            )
-            if (idx === -1) { continue }
-            const dataset = this.config.data.datasets[idx]
-            if (!dataset) { continue }
-            const value = data[field]
-            const isArray = Array.isArray(value) ? value.length > 1 : false
-            if (role === "2d-plot") {
-                this.drawingArray = false
-                this.drawingTwoFields = false
-                this.drawingAzEl = true
-                const scales = this.config.options.scales
-                if (("lon" in data) && ("lat" in data)) {
-                    dataset.data.push({ x: data["lon"], y: data["lat"] })
-                }
-                scales.x.title.text = "Azimuth [deg]"
-                scales.y.title.text = "Elevation [deg]"
-            } else if (role == "sis_iv") {
-                this.drawingArray = false
-                this.drawingTwoFields = true
-                this.drawingAzEl = false
-                const scales = this.config.options.scales
-                if (("voltage" in data) && ("current" in data)) {
-                    dataset.data.push({ x: data["voltage"], y: data["current"] })
-                }
-                scales.x.title.text = "Voltage [mV]"
-                scales.y.title.text = "Current [uA]"
-            } else if (isArray) {
-                if (role === "total_power") {
-                    const total_power = value.reduce((accumulator, currentValue) => accumulator + currentValue, 0)
-                    this.drawingArray = false
-                    this.drawingTwoFields = false
-                    this.drawingAzEl = false
-                    try {
-                        const time = data.time * 1e3 || Date.now()
-                        dataset.data.push({ x: time, y: total_power })
-                        const xMin = this.config.options.scales.x.min
-                        while ((dataset.data.length > 0) && (dataset.data[0].x < xMin)) { dataset.data.shift() }
-                    } catch (error) {
-                        console.debug(error)
-                    }
-                } else {
-                    this.drawingArray = true
-                    this.drawingTwoFields = false
-                    this.drawingAzEl = false
-                    dataset.data.length = 0
-                    dataset.data.push(...value.map((x, i) => { return { x: i, y: x } }))
-                }
+    push(message) {
+        const streamKey = message.stream_key || this.streamKey(message.topic_name, "", message.role || "")
+        const subscription = this.subscriptions.get(streamKey)
+        if (!subscription) { return }
+        const dataset = this.findDataset(streamKey)
+        if (!dataset) { return }
+        const data = message.data || {}
+        const field = subscription.field
+        if (!(field in data) && !["2d-plot", "sis_iv"].includes(subscription.role || "")) { return }
+        const value = data[field]
+        const isArray = Array.isArray(value)
+        const effectiveRole = subscription.role || message.role || this.activeRole
+
+        if (effectiveRole === "2d-plot") {
+            this.drawingArray = false
+            this.drawingTwoFields = false
+            this.drawingAzEl = true
+            const scales = this.config.options.scales
+            if (("lon" in data) && ("lat" in data)) {
+                dataset.data.push({ x: data["lon"], y: data["lat"] })
+                while (dataset.data.length > MAX_AZEL_POINTS) { dataset.data.shift() }
+            }
+            scales.x.title.text = "Azimuth [deg]"
+            scales.y.title.text = "Elevation [deg]"
+        } else if (effectiveRole === "sis_iv") {
+            this.drawingArray = false
+            this.drawingTwoFields = true
+            this.drawingAzEl = false
+            const scales = this.config.options.scales
+            if (("voltage" in data) && ("current" in data)) {
+                dataset.data.push({ x: data["voltage"], y: data["current"] })
+                while (dataset.data.length > MAX_SIS_IV_POINTS) { dataset.data.shift() }
+            }
+            scales.x.title.text = "Voltage [mV]"
+            scales.y.title.text = "Current [uA]"
+        } else if (isArray) {
+            this.drawingArray = true
+            this.drawingTwoFields = false
+            this.drawingAzEl = false
+            dataset.data.length = 0
+            const xValues = Array.isArray(data.observer_x_values) ? data.observer_x_values : null
+            if (xValues && xValues.length === value.length) {
+                dataset.data.push(...value.map((y, i) => { return { x: xValues[i], y } }))
             } else {
-                this.drawingArray = false
-                this.drawingTwoFields = false
-                this.drawingAzEl = false
-                try {
-                    const time = data.time * 1e3 || Date.now()
-                    dataset.data.push({ x: time, y: value })
-                    const xMin = this.config.options.scales.x.min
-                    while ((dataset.data.length > 0) && (dataset.data[0].x < xMin)) { dataset.data.shift() }
-                } catch (error) {
-                    console.debug(error)
-                }
+                dataset.data.push(...value.map((y, i) => { return { x: i, y } }))
+            }
+        } else {
+            this.drawingArray = false
+            this.drawingTwoFields = false
+            this.drawingAzEl = false
+            try {
+                const timeValue = (("time" in data) ? data.time : undefined)
+                const sampleTime = Number(timeValue)
+                const time = Number.isFinite(sampleTime) ? sampleTime * 1e3 : Date.now()
+                dataset.data.push({ x: time, y: value })
+                const xMin = this.config.options.scales.x.min
+                while ((dataset.data.length > 0) && (dataset.data[0].x < xMin)) { dataset.data.shift() }
+            } catch (error) {
+                console.debug(error)
             }
         }
     }
@@ -219,11 +374,10 @@ class _Graph {
     }
 
     clear() {
-        for (let [topic, fields] of Array.from(this.subscriptions.entries())) {
-            for (let field of [...fields]) {
-                this.removeDataset(topic, field)
-            }
+        for (let entry of Array.from(this.subscriptions.values())) {
+            this.removeDataset(entry.topic, entry.field, entry.role, entry.options)
         }
+        this.config.data.datasets = []
     }
 }
 

--- a/observer/static/index.js
+++ b/observer/static/index.js
@@ -1,103 +1,28 @@
-"use strict";
+"use strict"
 
-import * as quickLook from "./quick-look.js";
-import { Graph } from "./chart.js";
+import * as quickLook from "./quick-look.js"
+import { Graph } from "./chart.js"
 
-function getTotalPowerRangeFromUI() {
-  const startRaw = $("#tp-ch-start").val();
-  const endRaw = $("#tp-ch-end").val();
-  const start = startRaw === "" ? null : Number(startRaw);
-  const end = endRaw === "" ? null : Number(endRaw);
-  return {
-    start: Number.isFinite(start) ? start : null,
-    end: Number.isFinite(end) ? end : null,
-  };
-}
+const socket = io("/qlook")
+let currentRole = ""
 
-function applyTotalPowerRange(socket) {
-  const graph = Graph("#chart", socket);
-  const range = getTotalPowerRangeFromUI();
-  graph.setTotalPowerChRange(range.start, range.end);
+function requestTopicList(role = "") {
+    currentRole = role
+    Graph("#chart", socket).clear()
+    socket.emit("ros2-topic-list-request", { role })
 }
 
 function main() {
-  const socket = io("/qlook");
-  const role = "";
-  $("#ros2-topic-list").click(() => {
-    Graph("#chart", socket).clear();
-    socket.emit("ros2-topic-list-request", { role: role });
-  });
+    $("#ros2-topic-list").click(() => requestTopicList(""))
+    $("#total_power").click(() => requestTopicList("total_power"))
+    $("#2d-plot").click(() => requestTopicList("2d-plot"))
+    $("#sis_iv").click(() => requestTopicList("sis_iv"))
 
-  socket.on("ros2-topic-list", (msg) => quickLook.updateTopicList(socket, msg));
-  socket.on("ros2-topic-field", (msg) =>
-    quickLook.updateTopicField(socket, msg),
-  );
-  socket.on("ros2-message", (msg) => {
-    Graph("#chart", socket).push(msg.topic_name, msg.data);
-  });
+    socket.on("ros2-topic-list", msg => quickLook.updateTopicList(socket, msg))
+    socket.on("ros2-topic-field", msg => quickLook.updateTopicField(socket, msg))
+    socket.on("ros2-message", msg => {
+        Graph("#chart", socket).push(msg.topic_name, msg.data, currentRole)
+    })
 }
 
-function Sub() {
-  const socket = io("/qlook");
-  const role = "total_power";
-  const applyRange = () => applyTotalPowerRange(socket);
-
-  $("#total_power").click(() => {
-    applyRange();
-    socket.emit("ros2-topic-list-request", { role: role });
-  });
-
-  $("#tp-ch-apply").click(applyRange);
-  $("#tp-ch-start").on("change", applyRange);
-  $("#tp-ch-end").on("change", applyRange);
-
-  socket.on("ros2-topic-list", (msg) => quickLook.updateTopicList(socket, msg));
-  socket.on("ros2-topic-field", (msg) =>
-    quickLook.updateTopicField(socket, msg),
-  );
-  socket.on("ros2-message", (msg) => {
-    Graph("#chart", socket).push(msg.topic_name, msg.data, role);
-  });
-}
-
-function sub2() {
-  const socket = io("/qlook");
-  const role = "2d-plot";
-  $("#2d-plot").click(() => {
-    // TODO: Update chart in 2D-plot mode from 1D-plot mode.
-    Graph("#chart", socket).clear();
-    socket.emit("ros2-topic-list-request", { role: role });
-  });
-
-  socket.on("ros2-topic-list", (msg) => quickLook.updateTopicList(socket, msg));
-  // TODO: Do not display buttons of fields.
-  socket.on("ros2-topic-field", (msg) =>
-    quickLook.updateTopicField(socket, msg),
-  );
-  socket.on("ros2-message", (msg) => {
-    Graph("#chart", socket).push(msg.topic_name, msg.data, role);
-  });
-}
-function sub3() {
-  const socket = io("/qlook");
-  const role = "sis_iv";
-  $("#sis_iv").click(() => {
-    // TODO: Update chart in 2D-plot mode from 1D-plot mode.
-    Graph("#chart", socket).clear();
-    socket.emit("ros2-topic-list-request", { role: role });
-  });
-
-  socket.on("ros2-topic-list", (msg) => quickLook.updateTopicList(socket, msg));
-  // TODO: Do not display buttons of fields.
-  socket.on("ros2-topic-field", (msg) =>
-    quickLook.updateTopicField(socket, msg),
-  );
-  socket.on("ros2-message", (msg) => {
-    Graph("#chart", socket).push(msg.topic_name, msg.data, role);
-  });
-}
-
-$(document).ready(main);
-$(document).ready(Sub);
-$(document).ready(sub2);
-$(document).ready(sub3);
+$(document).ready(main)

--- a/observer/static/index.js
+++ b/observer/static/index.js
@@ -1,81 +1,103 @@
-"use strict"
+"use strict";
 
-import * as quickLook from "./quick-look.js"
-import { Graph } from "./chart.js"
+import * as quickLook from "./quick-look.js";
+import { Graph } from "./chart.js";
 
+function getTotalPowerRangeFromUI() {
+  const startRaw = $("#tp-ch-start").val();
+  const endRaw = $("#tp-ch-end").val();
+  const start = startRaw === "" ? null : Number(startRaw);
+  const end = endRaw === "" ? null : Number(endRaw);
+  return {
+    start: Number.isFinite(start) ? start : null,
+    end: Number.isFinite(end) ? end : null,
+  };
+}
 
+function applyTotalPowerRange(socket) {
+  const graph = Graph("#chart", socket);
+  const range = getTotalPowerRangeFromUI();
+  graph.setTotalPowerChRange(range.start, range.end);
+}
 
 function main() {
-    const socket = io("/qlook")
-    const role = ""
-    $("#ros2-topic-list").click(
-        () => {
-            Graph("#chart", socket).clear()
-            socket.emit("ros2-topic-list-request", { "role": role })
-        }
-    )
+  const socket = io("/qlook");
+  const role = "";
+  $("#ros2-topic-list").click(() => {
+    Graph("#chart", socket).clear();
+    socket.emit("ros2-topic-list-request", { role: role });
+  });
 
-    socket.on("ros2-topic-list", msg => quickLook.updateTopicList(socket, msg))
-    socket.on("ros2-topic-field", msg => quickLook.updateTopicField(socket, msg))
-    socket.on("ros2-message", msg => {
-        Graph("#chart", socket).push(msg.topic_name, msg.data)
-    })
+  socket.on("ros2-topic-list", (msg) => quickLook.updateTopicList(socket, msg));
+  socket.on("ros2-topic-field", (msg) =>
+    quickLook.updateTopicField(socket, msg),
+  );
+  socket.on("ros2-message", (msg) => {
+    Graph("#chart", socket).push(msg.topic_name, msg.data);
+  });
 }
 
 function Sub() {
-    const socket = io("/qlook")
-    const role = "total_power"
-    $("#total_power").click(
-        () => {
-            socket.emit("ros2-topic-list-request", { "role": role })
-        }
-    )
+  const socket = io("/qlook");
+  const role = "total_power";
+  const applyRange = () => applyTotalPowerRange(socket);
 
-    socket.on("ros2-topic-list", msg => quickLook.updateTopicList(socket, msg))
-    socket.on("ros2-topic-field", msg => quickLook.updateTopicField(socket, msg))
-    socket.on("ros2-message", msg => {
-        Graph("#chart", socket).push(msg.topic_name, msg.data, role)
-    })
+  $("#total_power").click(() => {
+    applyRange();
+    socket.emit("ros2-topic-list-request", { role: role });
+  });
+
+  $("#tp-ch-apply").click(applyRange);
+  $("#tp-ch-start").on("change", applyRange);
+  $("#tp-ch-end").on("change", applyRange);
+
+  socket.on("ros2-topic-list", (msg) => quickLook.updateTopicList(socket, msg));
+  socket.on("ros2-topic-field", (msg) =>
+    quickLook.updateTopicField(socket, msg),
+  );
+  socket.on("ros2-message", (msg) => {
+    Graph("#chart", socket).push(msg.topic_name, msg.data, role);
+  });
 }
 
 function sub2() {
-    const socket = io("/qlook")
-    const role = "2d-plot"
-    $("#2d-plot").click(
-        () => {
-            // TODO: Update chart in 2D-plot mode from 1D-plot mode.
-            Graph("#chart", socket).clear()
-            socket.emit("ros2-topic-list-request", { "role": role })
-        }
-    )
+  const socket = io("/qlook");
+  const role = "2d-plot";
+  $("#2d-plot").click(() => {
+    // TODO: Update chart in 2D-plot mode from 1D-plot mode.
+    Graph("#chart", socket).clear();
+    socket.emit("ros2-topic-list-request", { role: role });
+  });
 
-    socket.on("ros2-topic-list", msg => quickLook.updateTopicList(socket, msg))
-    // TODO: Do not display buttons of fields.
-    socket.on("ros2-topic-field", msg => quickLook.updateTopicField(socket, msg))
-    socket.on("ros2-message", msg => {
-        Graph("#chart", socket).push(msg.topic_name, msg.data, role)
-    })
+  socket.on("ros2-topic-list", (msg) => quickLook.updateTopicList(socket, msg));
+  // TODO: Do not display buttons of fields.
+  socket.on("ros2-topic-field", (msg) =>
+    quickLook.updateTopicField(socket, msg),
+  );
+  socket.on("ros2-message", (msg) => {
+    Graph("#chart", socket).push(msg.topic_name, msg.data, role);
+  });
 }
 function sub3() {
-    const socket = io("/qlook")
-    const role = "sis_iv"
-    $("#sis_iv").click(
-        () => {
-            // TODO: Update chart in 2D-plot mode from 1D-plot mode.
-            Graph("#chart", socket).clear()
-            socket.emit("ros2-topic-list-request", { "role": role })
-        }
-    )
+  const socket = io("/qlook");
+  const role = "sis_iv";
+  $("#sis_iv").click(() => {
+    // TODO: Update chart in 2D-plot mode from 1D-plot mode.
+    Graph("#chart", socket).clear();
+    socket.emit("ros2-topic-list-request", { role: role });
+  });
 
-    socket.on("ros2-topic-list", msg => quickLook.updateTopicList(socket, msg))
-    // TODO: Do not display buttons of fields.
-    socket.on("ros2-topic-field", msg => quickLook.updateTopicField(socket, msg))
-    socket.on("ros2-message", msg => {
-        Graph("#chart", socket).push(msg.topic_name, msg.data, role)
-    })
+  socket.on("ros2-topic-list", (msg) => quickLook.updateTopicList(socket, msg));
+  // TODO: Do not display buttons of fields.
+  socket.on("ros2-topic-field", (msg) =>
+    quickLook.updateTopicField(socket, msg),
+  );
+  socket.on("ros2-message", (msg) => {
+    Graph("#chart", socket).push(msg.topic_name, msg.data, role);
+  });
 }
 
-$(document).ready(main)
-$(document).ready(Sub)
-$(document).ready(sub2)
-$(document).ready(sub3)
+$(document).ready(main);
+$(document).ready(Sub);
+$(document).ready(sub2);
+$(document).ready(sub3);

--- a/observer/static/index.js
+++ b/observer/static/index.js
@@ -3,26 +3,292 @@
 import * as quickLook from "./quick-look.js"
 import { Graph } from "./chart.js"
 
-const socket = io("/qlook")
+const socket = io("/qlook", { autoConnect: false })
 let currentRole = ""
+let statusPollId = null
+let statusRefreshId = null
+const streamStatusState = new Map()
+const streamStatusHistory = new Map()
+const STREAM_HISTORY_LIMIT = 20
 
-function requestTopicList(role = "") {
+function graph() {
+    return Graph("#chart", socket)
+}
+
+function setConnectionStatus(text, isConnected = false) {
+    const elem = $("#connection-status")
+    elem.text(text)
+    elem.toggleClass("connected", isConnected)
+    elem.toggleClass("disconnected", !isConnected)
+}
+
+function setObserverStatus(text) {
+    $("#observer-status").text(text)
+}
+
+function parseOptionalIntegerInput(selector) {
+    const rawText = `${$(selector).val() ?? ""}`.trim()
+    if (!rawText.length) {
+        return undefined
+    }
+    const value = Number.parseInt(rawText, 10)
+    return Number.isFinite(value) ? value : undefined
+}
+
+function roleOptionsFromControls(role = currentRole) {
+    if (role === "spectrum_decimated") {
+        const raw = Number.parseInt($("#max-points-input").val(), 10)
+        const maxPoints = Number.isFinite(raw) ? raw : 1024
+        const options = { max_points: maxPoints }
+        const channelStart = parseOptionalIntegerInput("#decimation-channel-start-input")
+        const channelStop = parseOptionalIntegerInput("#decimation-channel-stop-input")
+        if (channelStart !== undefined) {
+            options.channel_start = channelStart
+        }
+        if (channelStop !== undefined) {
+            options.channel_stop = channelStop
+        }
+        return options
+    }
+    if (role === "total_power") {
+        const options = {}
+        const channelStart = parseOptionalIntegerInput("#channel-start-input")
+        const channelStop = parseOptionalIntegerInput("#channel-stop-input")
+        if (channelStart !== undefined) {
+            options.channel_start = channelStart
+        }
+        if (channelStop !== undefined) {
+            options.channel_stop = channelStop
+        }
+        return options
+    }
+    return {}
+}
+
+function syncControlsFromRole(role = currentRole) {
+    const options = graph().getRoleOptions(role)
+    const currentValue = options.max_points || 1024
+    $("#max-points-input").val(currentValue)
+    $("#decimation-channel-start-input").val(options.channel_start ?? "")
+    $("#decimation-channel-stop-input").val(options.channel_stop ?? "")
+    $("#channel-start-input").val(options.channel_start ?? "")
+    $("#channel-stop-input").val(options.channel_stop ?? "")
+    const showDecimation = role === "spectrum_decimated"
+    const showTotalPower = role === "total_power"
+    $("#decimation-controls").toggleClass("hidden", !showDecimation)
+    $("#total-power-controls").toggleClass("hidden", !showTotalPower)
+}
+
+function formatAgeFromStatus(stream, key) {
+    const timestamp = stream?.[key]
+    if (timestamp == null) {
+        return "-"
+    }
+    const serverTime = Number(stream?.server_time)
+    const receivedAtMs = Number(stream?._received_at_ms)
+    let age = NaN
+    if (Number.isFinite(serverTime)) {
+        const baseAge = serverTime - Number(timestamp)
+        if (Number.isFinite(baseAge)) {
+            const extraAge = Number.isFinite(receivedAtMs) ? ((Date.now() - receivedAtMs) / 1000.0) : 0.0
+            age = baseAge + extraAge
+        }
+    }
+    if (!Number.isFinite(age)) {
+        age = Date.now() / 1000.0 - Number(timestamp)
+    }
+    return Number.isFinite(age) ? `${Math.max(0, age).toFixed(1)}s` : "-"
+}
+
+function summarizeHistory(streamKey) {
+    const history = streamStatusHistory.get(streamKey) || []
+    if (!history.length) {
+        return "no recent transitions"
+    }
+    return history.slice().reverse().map(item => `${item.at_text}: ${item.from} -> ${item.to}`).join("\n")
+}
+
+function badgeTextForStream(stream) {
+    const desc = graph().describeStream(stream.stream_key)
+    const emitAge = formatAgeFromStatus(stream, "last_emit_time")
+    const rxAge = formatAgeFromStatus(stream, "last_rx_time")
+    return `${desc.label} | ${stream.status} | emit_age=${emitAge} | rx_age=${rxAge} | throttled=${stream.throttle_count}`
+}
+
+function tooltipTextForStream(stream) {
+    const desc = graph().describeStream(stream.stream_key)
+    const lines = [
+        desc.label,
+        `status=${stream.status}`,
+        `last_emit_age=${formatAgeFromStatus(stream, "last_emit_time")}`,
+        `last_rx_age=${formatAgeFromStatus(stream, "last_rx_time")}`,
+        `last_throttle_age=${formatAgeFromStatus(stream, "last_throttle_time")}`,
+        `emit_count=${stream.emit_count ?? 0}`,
+        `rx_count=${stream.rx_count ?? 0}`,
+        `throttle_count=${stream.throttle_count ?? 0}`,
+        `client_count=${stream.client_count ?? 0}`,
+        "history:",
+        summarizeHistory(stream.stream_key),
+    ]
+    return lines.join("\n")
+}
+
+function updateStreamStatusHistories(streams = []) {
+    const activeKeys = new Set(streams.map(stream => stream.stream_key))
+    const currentSubscriptions = new Set(graph().listStreamKeys())
+    for (let [streamKey, previous] of Array.from(streamStatusState.entries())) {
+        if (!activeKeys.has(streamKey)) {
+            streamStatusState.delete(streamKey)
+        }
+    }
+    for (let streamKey of Array.from(streamStatusHistory.keys())) {
+        if (!activeKeys.has(streamKey) && !currentSubscriptions.has(streamKey)) {
+            streamStatusHistory.delete(streamKey)
+        }
+    }
+    for (let stream of streams) {
+        const previous = streamStatusState.get(stream.stream_key)
+        if (previous && previous.status !== stream.status) {
+            const history = streamStatusHistory.get(stream.stream_key) || []
+            history.push({
+                at: Date.now(),
+                at_text: new Date().toLocaleTimeString(),
+                from: previous.status,
+                to: stream.status,
+            })
+            while (history.length > STREAM_HISTORY_LIMIT) {
+                history.shift()
+            }
+            streamStatusHistory.set(stream.stream_key, history)
+        } else if (!previous && !streamStatusHistory.has(stream.stream_key)) {
+            streamStatusHistory.set(stream.stream_key, [])
+        }
+        streamStatusState.set(stream.stream_key, { ...stream, _received_at_ms: Date.now() })
+    }
+}
+
+function renderStreamStatuses(streams = null) {
+    const container = $("#stream-status-list")
+    const stateStreams = streams || Array.from(streamStatusState.values())
+    if (streams) {
+        updateStreamStatusHistories(streams)
+    }
+    container.empty()
+    if (!stateStreams.length) {
+        $("<code>").addClass("status-chip idle").text("no selected streams").appendTo(container)
+        return
+    }
+    for (let stream of stateStreams) {
+        $("<code>")
+            .addClass(`status-chip ${stream.status || 'idle'}`)
+            .attr("title", tooltipTextForStream(stream))
+            .text(badgeTextForStream(stream))
+            .appendTo(container)
+    }
+}
+
+function requestTopicList(role = "", { clearGraph = true } = {}) {
     currentRole = role
-    Graph("#chart", socket).clear()
+    const options = roleOptionsFromControls(role)
+    graph().setRole(role, options)
+    syncControlsFromRole(role)
+    if (clearGraph) {
+        graph().clear()
+    }
     socket.emit("ros2-topic-list-request", { role })
 }
 
-function main() {
-    $("#ros2-topic-list").click(() => requestTopicList(""))
-    $("#total_power").click(() => requestTopicList("total_power"))
-    $("#2d-plot").click(() => requestTopicList("2d-plot"))
-    $("#sis_iv").click(() => requestTopicList("sis_iv"))
+function pollObserverStatus() {
+    socket.emit("ros2-status-request", {
+        stream_keys: graph().listStreamKeys(),
+    })
+}
+
+function startStatusPolling() {
+    if (statusPollId !== null) {
+        clearInterval(statusPollId)
+    }
+    statusPollId = setInterval(() => {
+        if (socket.connected) {
+            pollObserverStatus()
+        }
+    }, 30000)
+    if (statusRefreshId !== null) {
+        clearInterval(statusRefreshId)
+    }
+    statusRefreshId = setInterval(() => {
+        if (streamStatusState.size > 0) {
+            renderStreamStatuses()
+        }
+    }, 1000)
+}
+
+function restoreStateAfterReconnect() {
+    requestTopicList(currentRole, { clearGraph: false })
+    graph().restoreSubscriptions()
+    pollObserverStatus()
+}
+
+function applyRoleOptions() {
+    const role = currentRole || graph().activeRole || ""
+    const options = roleOptionsFromControls(role)
+    graph().updateCurrentRoleOptions(options)
+    syncControlsFromRole(role)
+    pollObserverStatus()
+}
+
+function bindSocketEvents() {
+    socket.on("connect", () => {
+        setConnectionStatus("connected", true)
+        restoreStateAfterReconnect()
+    })
+    socket.on("disconnect", reason => {
+        setConnectionStatus(`disconnected (${reason})`, false)
+    })
+    socket.io.on("reconnect_attempt", attempt => {
+        setConnectionStatus(`reconnecting (${attempt})`, false)
+    })
+    socket.io.on("reconnect", () => {
+        setConnectionStatus("reconnected", true)
+    })
 
     socket.on("ros2-topic-list", msg => quickLook.updateTopicList(socket, msg))
     socket.on("ros2-topic-field", msg => quickLook.updateTopicField(socket, msg))
     socket.on("ros2-message", msg => {
-        Graph("#chart", socket).push(msg.topic_name, msg.data, currentRole)
+        graph().push(msg)
     })
+    socket.on("ros2-subscribe", () => {
+        pollObserverStatus()
+    })
+    socket.on("ros2-unsubscribe", () => {
+        pollObserverStatus()
+    })
+    socket.on("ros2-status", msg => {
+        const health = msg.health || {}
+        const streams = msg.streams || []
+        const pushInfo = (health.status_push_enabled)
+            ? `, push=${health.status_push_mode || 'change+heartbeat'} (hb=${health.status_push_heartbeat_sec || 10.0}s)`
+            : ""
+        setObserverStatus(`clients=${health.active_clients || 0}, topics=${health.active_topics || 0}, streams=${health.active_streams || 0}${pushInfo}`)
+        renderStreamStatuses(streams)
+    })
+}
+
+function main() {
+    setConnectionStatus("connecting", false)
+    graph().setRole(currentRole, roleOptionsFromControls(currentRole))
+    syncControlsFromRole(currentRole)
+
+    $("#ros2-topic-list").click(() => requestTopicList(""))
+    $("#total_power").click(() => requestTopicList("total_power"))
+    $("#spectrum_decimated").click(() => requestTopicList("spectrum_decimated"))
+    $("#2d-plot").click(() => requestTopicList("2d-plot"))
+    $("#sis_iv").click(() => requestTopicList("sis_iv"))
+    $(".apply-role-options").click(() => applyRoleOptions())
+
+    bindSocketEvents()
+    startStatusPolling()
+    socket.connect()
 }
 
 $(document).ready(main)

--- a/observer/static/index.js
+++ b/observer/static/index.js
@@ -169,13 +169,14 @@ function updateStreamStatusHistories(streams = []) {
 
 function renderStreamStatuses(streams = null) {
     const container = $("#stream-status-list")
+    const panel = $("#stream-status-panel")
     const stateStreams = streams || Array.from(streamStatusState.values())
     if (streams) {
         updateStreamStatusHistories(streams)
     }
     container.empty()
     if (!stateStreams.length) {
-        $("<code>").addClass("status-chip idle").text("no selected streams").appendTo(container)
+        panel.removeAttr("open")
         return
     }
     for (let stream of stateStreams) {

--- a/observer/static/quick-look.js
+++ b/observer/static/quick-look.js
@@ -1,9 +1,7 @@
 "use strict"
 
 import { parseDataType } from "./ros-tools.js"
-import { toMap } from "./utils.js"
 import { Graph } from "./chart.js"
-
 
 function updateTopicList(socket, msg = {topic_split: {}}) {
     const container = $("#category-list")
@@ -12,17 +10,18 @@ function updateTopicList(socket, msg = {topic_split: {}}) {
     container2.empty()
     const container3 = $("#message-fields")
     container3.empty()
-    const topic_list = Object.keys(msg.topic_split)
-    const topics = toMap(topic_list)
+    const topic_entries = Object.entries(msg.topic_split)
+    const topics = new Map(topic_entries)
     if (!topics.size) { return }
     const cat = {}
-    for (let topic of topics.values()) {
-        const [blanck, cat_name, ..._topic_name] = topic.split("/")
+    for (let [fullTopic, meta] of topics.entries()) {
+        const displayTopic = meta.display_topic || meta.topic || fullTopic
+        const [, cat_name, ..._topic_name] = displayTopic.split("/")
         const topic_name = _topic_name.join("/")
-        if (cat_name in cat){
-            cat[cat_name].push(topic_name)
+        if (cat_name in cat) {
+            cat[cat_name].push({label: topic_name, fullTopic})
         } else {
-            cat[cat_name] = [topic_name]
+            cat[cat_name] = [{label: topic_name, fullTopic}]
         }
     }
     for (let cat_name of Object.keys(cat)) {
@@ -31,13 +30,18 @@ function updateTopicList(socket, msg = {topic_split: {}}) {
             () => {
                 container2.empty()
                 container3.empty()
-                for (let name of cat[cat_name]) {
-                    const text_ = $("<code>").text(name)
+                for (let entry of cat[cat_name]) {
+                    const text_ = $("<code>").text(entry.label)
                     $("<button>").html(text_).appendTo(container2).click(
-                        () =>{
-                        const topic = ["", cat_name, name].join("/")
-                        socket.emit("ros2-topic-field-request", 
-                        { topic_name: [msg.topic_split[topic].system, msg.topic_split[topic].observatory, topic]})
+                        () => {
+                            const meta = msg.topic_split[entry.fullTopic]
+                            if (!meta) {
+                                console.warn(`Topic info not found for ${entry.fullTopic}`)
+                                return
+                            }
+                            const topic = meta.topic || entry.fullTopic
+                            socket.emit("ros2-topic-field-request",
+                                { topic_name: [meta.system, meta.observatory, topic] })
                         }
                     )
                 }
@@ -49,9 +53,17 @@ function updateTopicList(socket, msg = {topic_split: {}}) {
 function updateTopicField(socket, msg = { topic_name: "", fields: [], error: "" }) {
     const container = $("#message-fields")
     container.empty()
-    if (msg.error) { throw `Server error: ${msg.error}` }
-    const fields = toMap(msg.fields)
-    if (!fields.size) { throw "Message for the topic has no field info." }
+    if (msg.error) {
+        console.warn(`Server error: ${msg.error}`)
+        $("<code>").text(`Server error: ${msg.error}`).appendTo(container)
+        return
+    }
+    const fields = new Map(Object.entries(msg.fields || {}))
+    if (!fields.size) {
+        console.warn("Message for the topic has no field info.")
+        $("<code>").text("Message for the topic has no field info.").appendTo(container)
+        return
+    }
     for (let [name, type] of fields) {
         const text = $("<code>").text(name)
         const dataKind = parseDataType(type)

--- a/observer/static/quick-look.js
+++ b/observer/static/quick-look.js
@@ -64,13 +64,32 @@ function updateTopicField(socket, msg = { topic_name: "", fields: [], error: "" 
         $("<code>").text("Message for the topic has no field info.").appendTo(container)
         return
     }
-    for (let [name, type] of fields) {
-        const text = $("<code>").text(name)
-        const dataKind = parseDataType(type)
+    const activeRole = Graph("#chart", socket).activeRole || ""
+    if (["2d-plot", "sis_iv"].includes(activeRole)) {
+        const label = (activeRole === "2d-plot") ? "plot" : "curve"
+        const requiredFields = (activeRole === "2d-plot") ? ["lon", "lat"] : ["voltage", "current"]
+        const enabled = requiredFields.every(name => fields.has(name))
+        const text = $("<code>").text(label)
         $("<button>")
             .html(text)
             .appendTo(container)
-            .prop("disabled", !dataKind.numerical)
+            .prop("disabled", !enabled)
+            .attr("title", enabled ? "" : `requires fields: ${requiredFields.join(", ")}`)
+            .click(() => {
+                if (!enabled) { return }
+                Graph("#chart", socket).toggleDataset(msg.topic_name, "", activeRole)
+            })
+        return
+    }
+    for (let [name, type] of fields) {
+        const text = $("<code>").text(name)
+        const dataKind = parseDataType(type)
+        const requiresArray = ["total_power", "spectrum_decimated"].includes(activeRole)
+        const enabled = requiresArray ? (dataKind.numerical && dataKind.array) : dataKind.numerical
+        $("<button>")
+            .html(text)
+            .appendTo(container)
+            .prop("disabled", !enabled)
             .data(dataKind)
             .click(
                 () => {

--- a/observer/static/ros-tools.js
+++ b/observer/static/ros-tools.js
@@ -1,8 +1,15 @@
 "use strict"
 
 function parseDataType(typeSpec) {
-    const arrayType = typeSpec.startsWith("sequence")
-    const baseType = arrayType ? /sequence<(.*)>/.exec(typeSpec)[1] : typeSpec
+    const arrayType = typeSpec.startsWith("sequence") || /\[[0-9]*\]$/.test(typeSpec)
+    let baseType
+    if (typeSpec.startsWith("sequence")) {
+        baseType = /sequence<(.*)>/.exec(typeSpec)[1]
+    } else if (/\[[0-9]*\]$/.test(typeSpec)) {
+        baseType = typeSpec.replace(/\[[0-9]*\]$/, "")
+    } else {
+        baseType = typeSpec
+    }
     const numericalType = baseType.startsWith("int")
         || baseType.startsWith("uint")
         || baseType.startsWith("float")

--- a/observer/stream_keys.py
+++ b/observer/stream_keys.py
@@ -1,0 +1,46 @@
+import json
+from typing import Any, Dict, Iterable, List, Optional
+
+ROLE_USES_FIELDS = {"", "total_power", "spectrum_decimated"}
+
+
+def normalize_fields(fields: Optional[Iterable[str]]) -> List[str]:
+    if not fields:
+        return []
+    ordered = []
+    for field in fields:
+        if field and field not in ordered:
+            ordered.append(str(field))
+    return ordered
+
+
+
+def normalize_role_fields(role: str = "", fields: Optional[Iterable[str]] = None) -> List[str]:
+    normalized = normalize_fields(fields)
+    return normalized if (role or "") in ROLE_USES_FIELDS else []
+
+
+def normalize_options(options: Optional[Dict[str, Any]]) -> Dict[str, Any]:
+    if not options:
+        return {}
+    normalized: Dict[str, Any] = {}
+    for key, value in sorted(options.items(), key=lambda item: str(item[0])):
+        normalized[str(key)] = value
+    return normalized
+
+
+
+def make_stream_key(
+    topic: str,
+    *,
+    role: str = "",
+    fields: Optional[Iterable[str]] = None,
+    options: Optional[Dict[str, Any]] = None,
+) -> str:
+    payload = {
+        "topic": topic,
+        "role": role or "",
+        "fields": normalize_role_fields(role, fields),
+        "options": normalize_options(options),
+    }
+    return json.dumps(payload, sort_keys=True, separators=(",", ":"))

--- a/observer/stream_profiles.py
+++ b/observer/stream_profiles.py
@@ -1,0 +1,234 @@
+import array
+import math
+from typing import Any, Dict, Iterable, List, Optional, Tuple
+
+
+NUMERIC_TYPES = (int, float)
+ARRAY_TYPES = (list, tuple, array.array)
+DEFAULT_MAX_POINTS = 1024
+MIN_MAX_POINTS = 8
+MAX_MAX_POINTS = 16384
+
+
+def _is_finite_number(value: Any) -> bool:
+    return isinstance(value, NUMERIC_TYPES) and not isinstance(value, bool) and math.isfinite(value)
+
+
+
+def _iter_numeric_values(values: Iterable[Any]) -> List[float]:
+    numeric: List[float] = []
+    for value in values:
+        if _is_finite_number(value):
+            numeric.append(float(value))
+    return numeric
+
+
+
+def _is_numeric_array(value: Any) -> bool:
+    if not isinstance(value, ARRAY_TYPES):
+        return False
+    if len(value) == 0:
+        return False
+    return any(_is_finite_number(v) for v in value)
+
+
+
+def sanitize_max_points(value: Any, default: int = DEFAULT_MAX_POINTS) -> int:
+    try:
+        parsed = int(value)
+    except (TypeError, ValueError):
+        parsed = default
+    return max(MIN_MAX_POINTS, min(MAX_MAX_POINTS, parsed))
+
+
+
+def sanitize_channel_index(value: Any) -> Optional[int]:
+    if value in (None, ""):
+        return None
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return None
+
+
+
+def resolve_channel_range(
+    values: Any,
+    channel_start: Any = None,
+    channel_stop: Any = None,
+) -> Tuple[int, int]:
+    if not isinstance(values, ARRAY_TYPES) or len(values) == 0:
+        return (0, -1)
+    n = len(values)
+    start = sanitize_channel_index(channel_start)
+    stop = sanitize_channel_index(channel_stop)
+    if start is None:
+        start = 0
+    if stop is None:
+        stop = n - 1
+    start = max(0, min(n - 1, start))
+    stop = max(0, min(n - 1, stop))
+    if stop < start:
+        start, stop = stop, start
+    return (start, stop)
+
+
+
+def resolve_time_value(data: Dict[str, Any], fallback_time: Optional[float] = None) -> Optional[float]:
+    time_value = data.get("time")
+    if _is_finite_number(time_value):
+        return float(time_value)
+    return fallback_time
+
+
+def select_total_power_fields(data: Dict[str, Any], requested_fields: Optional[Iterable[str]] = None) -> List[str]:
+    if requested_fields is not None:
+        return [field for field in requested_fields if _is_numeric_array(data.get(field))]
+    return [field for field, value in data.items() if _is_numeric_array(value)]
+
+
+
+def build_total_power_payload(
+    data: Dict[str, Any],
+    requested_fields: Optional[Iterable[str]] = None,
+    *,
+    channel_start: Any = None,
+    channel_stop: Any = None,
+    fallback_time: Optional[float] = None,
+) -> Dict[str, Any]:
+    payload: Dict[str, Any] = {}
+    fields = select_total_power_fields(data, requested_fields)
+    resolved_range: Optional[Tuple[int, int]] = None
+    for field in fields:
+        raw_values = data.get(field, [])
+        if not isinstance(raw_values, ARRAY_TYPES) or len(raw_values) == 0:
+            continue
+        start, stop = resolve_channel_range(raw_values, channel_start, channel_stop)
+        if stop < start:
+            continue
+        resolved_range = (start, stop)
+        numeric_values = _iter_numeric_values(raw_values[start : stop + 1])
+        if numeric_values:
+            payload[field] = sum(numeric_values)
+    has_data_field = any(field in payload for field in fields)
+    if not has_data_field:
+        return {}
+    resolved_time = resolve_time_value(data, fallback_time)
+    if resolved_time is not None:
+        payload["time"] = resolved_time
+    payload["observer_profile"] = "total_power"
+    if resolved_range is not None:
+        payload["observer_channel_start"] = resolved_range[0]
+        payload["observer_channel_stop"] = resolved_range[1]
+    return payload
+
+
+
+def _collect_indexed_numeric_values(values: Iterable[Any], start_index: int = 0) -> List[Tuple[int, float]]:
+    indexed: List[Tuple[int, float]] = []
+    for offset, value in enumerate(values):
+        if _is_finite_number(value):
+            indexed.append((start_index + offset, float(value)))
+    return indexed
+
+
+
+def _downsample_indexed_pairs(indexed_values: List[Tuple[int, float]], max_points: int = DEFAULT_MAX_POINTS) -> List[Tuple[int, float]]:
+    max_points = sanitize_max_points(max_points)
+    if len(indexed_values) <= max_points:
+        return indexed_values
+    if max_points == 1:
+        return [indexed_values[-1]]
+    last_index = len(indexed_values) - 1
+    sampled_indices = []
+    for i in range(max_points):
+        idx = round(i * last_index / (max_points - 1))
+        if (not sampled_indices) or (idx != sampled_indices[-1]):
+            sampled_indices.append(idx)
+    if sampled_indices[-1] != last_index:
+        sampled_indices[-1] = last_index
+    return [indexed_values[idx] for idx in sampled_indices]
+
+
+
+def downsample_array(values: Iterable[Any], max_points: int = DEFAULT_MAX_POINTS) -> List[float]:
+    indexed = _collect_indexed_numeric_values(values)
+    return [value for _, value in _downsample_indexed_pairs(indexed, max_points=max_points)]
+
+
+
+def build_decimated_payload(
+    data: Dict[str, Any],
+    requested_fields: Optional[Iterable[str]] = None,
+    *,
+    max_points: int = DEFAULT_MAX_POINTS,
+    channel_start: Any = None,
+    channel_stop: Any = None,
+    fallback_time: Optional[float] = None,
+) -> Dict[str, Any]:
+    payload: Dict[str, Any] = {}
+    fields = select_total_power_fields(data, requested_fields)
+    max_points = sanitize_max_points(max_points)
+    resolved_range: Optional[Tuple[int, int]] = None
+    x_values: Optional[List[int]] = None
+    for field in fields:
+        raw_values = data.get(field, [])
+        if not isinstance(raw_values, ARRAY_TYPES) or len(raw_values) == 0:
+            continue
+        start, stop = resolve_channel_range(raw_values, channel_start, channel_stop)
+        if stop < start:
+            continue
+        resolved_range = (start, stop)
+        sliced = raw_values[start : stop + 1]
+        indexed_numeric = _collect_indexed_numeric_values(sliced, start_index=start)
+        decimated_pairs = _downsample_indexed_pairs(indexed_numeric, max_points=max_points)
+        if not decimated_pairs:
+            continue
+        payload[field] = [value for _, value in decimated_pairs]
+        if x_values is None:
+            x_values = [idx for idx, _ in decimated_pairs]
+    has_data_field = any(field in payload for field in fields)
+    if not has_data_field:
+        return {}
+    resolved_time = resolve_time_value(data, fallback_time)
+    if resolved_time is not None:
+        payload["time"] = resolved_time
+    payload["observer_profile"] = "spectrum_decimated"
+    payload["observer_max_points"] = max_points
+    if resolved_range is not None:
+        payload["observer_channel_start"] = resolved_range[0]
+        payload["observer_channel_stop"] = resolved_range[1]
+    if x_values is not None:
+        payload["observer_x_values"] = x_values
+    return payload
+
+
+
+def transform_payload(
+    data: Dict[str, Any],
+    *,
+    role: str = "",
+    fields: Optional[Iterable[str]] = None,
+    options: Optional[Dict[str, Any]] = None,
+    fallback_time: Optional[float] = None,
+) -> Dict[str, Any]:
+    options = options or {}
+    if role == "total_power":
+        return build_total_power_payload(
+            data,
+            fields,
+            channel_start=options.get("channel_start"),
+            channel_stop=options.get("channel_stop"),
+            fallback_time=fallback_time,
+        )
+    if role == "spectrum_decimated":
+        max_points = sanitize_max_points(options.get("max_points", DEFAULT_MAX_POINTS))
+        return build_decimated_payload(
+            data,
+            fields,
+            max_points=max_points,
+            channel_start=options.get("channel_start"),
+            channel_stop=options.get("channel_stop"),
+            fallback_time=fallback_time,
+        )
+    return data

--- a/observer/templates/qlook/index.html
+++ b/observer/templates/qlook/index.html
@@ -1,60 +1,91 @@
-<!DOCTYPE html>
+<!doctype html>
 <html>
-
-<head>
-    <meta charset="utf-8">
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/3.6.0/jquery.min.js"
-        integrity="sha512-894YE6QWD5I59HgZOGReFYm4dnWc1Qt5NtvYSaNcOP+u1T9qYdvdihz0PPSiiqn/+/3e7Jo4EaG7TubfWGUrMQ=="
-        crossorigin="anonymous" referrerpolicy="no-referrer"></script>
+  <head>
+    <meta charset="utf-8" />
+    <script
+      src="https://cdnjs.cloudflare.com/ajax/libs/jquery/3.6.0/jquery.min.js"
+      integrity="sha512-894YE6QWD5I59HgZOGReFYm4dnWc1Qt5NtvYSaNcOP+u1T9qYdvdihz0PPSiiqn/+/3e7Jo4EaG7TubfWGUrMQ=="
+      crossorigin="anonymous"
+      referrerpolicy="no-referrer"
+    ></script>
     <script src="https://cdn.jsdelivr.net/npm/chart.js@4.0.1/dist/chart.umd.min.js"></script>
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/socket.io/4.0.1/socket.io.js"
-        integrity="sha512-q/dWJ3kcmjBLU4Qc47E4A9kTB4m3wuTY7vkFJDTZKjTs8jhyGQnaUrxa0Ytd0ssMZhbNua9hE+E7Qv1j+DyZwA=="
-        crossorigin="anonymous"></script>
-    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/Chart.js/2.9.4/Chart.min.css"
-        integrity="sha512-/zs32ZEJh+/EO2N1b0PEdoA10JkdC3zJ8L5FTiQu82LR9S/rOQNfQN7U59U9BC12swNeRAz3HSzIL2vpp4fv3w=="
-        crossorigin="anonymous" referrerpolicy="no-referrer" />
+    <script
+      src="https://cdnjs.cloudflare.com/ajax/libs/socket.io/4.0.1/socket.io.js"
+      integrity="sha512-q/dWJ3kcmjBLU4Qc47E4A9kTB4m3wuTY7vkFJDTZKjTs8jhyGQnaUrxa0Ytd0ssMZhbNua9hE+E7Qv1j+DyZwA=="
+      crossorigin="anonymous"
+    ></script>
+    <link
+      rel="stylesheet"
+      href="https://cdnjs.cloudflare.com/ajax/libs/Chart.js/2.9.4/Chart.min.css"
+      integrity="sha512-/zs32ZEJh+/EO2N1b0PEdoA10JkdC3zJ8L5FTiQu82LR9S/rOQNfQN7U59U9BC12swNeRAz3HSzIL2vpp4fv3w=="
+      crossorigin="anonymous"
+      referrerpolicy="no-referrer"
+    />
     <title>ROS 2 Topic Visualization</title>
-</head>
+  </head>
 
-<body>
+  <body>
     {% include "header.html" %}
     <div class="container">
-        <div id="requests">
-            <button type="button" id="ros2-topic-list">
-                <code>ros2 topic list</code>
-            </button>
-            <button type="button" id="total_power">
-                <code>total_power</code>
-            </button>
-            <button type="button" id="2d-plot">
-                <code>2d plot</code>
-            </button>
-            <button type="button" id="sis_iv">
-                <code>SIS IV</code>
-            </button>
-        </div>
-        <div id="selects">
-            <div id="category-list"></div>
-            <div id="topic-list"></div>
-            <div id="message-fields"></div>
-        </div>
-        <div id="charts">
-            <canvas id="chart"></canvas>
-        </div>
+      <div id="requests">
+        <button type="button" id="ros2-topic-list">
+          <code>ros2 topic list</code>
+        </button>
+        <button type="button" id="total_power">
+          <code>total_power</code>
+        </button>
+        <label for="tp-ch-start">TP ch start</label>
+        <input
+          type="number"
+          id="tp-ch-start"
+          min="0"
+          step="1"
+          placeholder="0"
+          style="width: 90px"
+        />
+        <label for="tp-ch-end">TP ch end</label>
+        <input
+          type="number"
+          id="tp-ch-end"
+          min="0"
+          step="1"
+          placeholder="all"
+          style="width: 90px"
+        />
+        <button type="button" id="tp-ch-apply">
+          <code>apply ch</code>
+        </button>
+        <button type="button" id="2d-plot">
+          <code>2d plot</code>
+        </button>
+        <button type="button" id="sis_iv">
+          <code>SIS IV</code>
+        </button>
+      </div>
+      <div id="selects">
+        <div id="category-list"></div>
+        <div id="topic-list"></div>
+        <div id="message-fields"></div>
+      </div>
+      <div id="charts">
+        <canvas id="chart"></canvas>
+      </div>
     </div>
     <style>
-        .container {
-            padding: 5px 10px;
-            width: 100%;
-            height: calc(100vh - 2em);
-        }
+      .container {
+        padding: 5px 10px;
+        width: 100%;
+        height: calc(100vh - 2em);
+      }
 
-        .charts {
-            width: 100%;
-            height: 100%;
-        }
+      .charts {
+        width: 100%;
+        height: 100%;
+      }
     </style>
-    <script type="module" src="{{url_for('static', filename='index.js')}}"></script>
-</body>
-
+    <script
+      type="module"
+      src="{{url_for('static', filename='index.js')}}"
+    ></script>
+  </body>
 </html>

--- a/observer/templates/qlook/index.html
+++ b/observer/templates/qlook/index.html
@@ -1,91 +1,60 @@
-<!doctype html>
+<!DOCTYPE html>
 <html>
-  <head>
-    <meta charset="utf-8" />
-    <script
-      src="https://cdnjs.cloudflare.com/ajax/libs/jquery/3.6.0/jquery.min.js"
-      integrity="sha512-894YE6QWD5I59HgZOGReFYm4dnWc1Qt5NtvYSaNcOP+u1T9qYdvdihz0PPSiiqn/+/3e7Jo4EaG7TubfWGUrMQ=="
-      crossorigin="anonymous"
-      referrerpolicy="no-referrer"
-    ></script>
-    <script src="https://cdn.jsdelivr.net/npm/chart.js@4.0.1/dist/chart.umd.min.js"></script>
-    <script
-      src="https://cdnjs.cloudflare.com/ajax/libs/socket.io/4.0.1/socket.io.js"
-      integrity="sha512-q/dWJ3kcmjBLU4Qc47E4A9kTB4m3wuTY7vkFJDTZKjTs8jhyGQnaUrxa0Ytd0ssMZhbNua9hE+E7Qv1j+DyZwA=="
-      crossorigin="anonymous"
-    ></script>
-    <link
-      rel="stylesheet"
-      href="https://cdnjs.cloudflare.com/ajax/libs/Chart.js/2.9.4/Chart.min.css"
-      integrity="sha512-/zs32ZEJh+/EO2N1b0PEdoA10JkdC3zJ8L5FTiQu82LR9S/rOQNfQN7U59U9BC12swNeRAz3HSzIL2vpp4fv3w=="
-      crossorigin="anonymous"
-      referrerpolicy="no-referrer"
-    />
-    <title>ROS 2 Topic Visualization</title>
-  </head>
 
-  <body>
+<head>
+    <meta charset="utf-8">
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/3.6.0/jquery.min.js"
+        integrity="sha512-894YE6QWD5I59HgZOGReFYm4dnWc1Qt5NtvYSaNcOP+u1T9qYdvdihz0PPSiiqn/+/3e7Jo4EaG7TubfWGUrMQ=="
+        crossorigin="anonymous" referrerpolicy="no-referrer"></script>
+    <script src="https://cdn.jsdelivr.net/npm/chart.js@4.0.1/dist/chart.umd.min.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/socket.io/4.0.1/socket.io.js"
+        integrity="sha512-q/dWJ3kcmjBLU4Qc47E4A9kTB4m3wuTY7vkFJDTZKjTs8jhyGQnaUrxa0Ytd0ssMZhbNua9hE+E7Qv1j+DyZwA=="
+        crossorigin="anonymous"></script>
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/Chart.js/2.9.4/Chart.min.css"
+        integrity="sha512-/zs32ZEJh+/EO2N1b0PEdoA10JkdC3zJ8L5FTiQu82LR9S/rOQNfQN7U59U9BC12swNeRAz3HSzIL2vpp4fv3w=="
+        crossorigin="anonymous" referrerpolicy="no-referrer" />
+    <title>ROS 2 Topic Visualization</title>
+</head>
+
+<body>
     {% include "header.html" %}
     <div class="container">
-      <div id="requests">
-        <button type="button" id="ros2-topic-list">
-          <code>ros2 topic list</code>
-        </button>
-        <button type="button" id="total_power">
-          <code>total_power</code>
-        </button>
-        <label for="tp-ch-start">TP ch start</label>
-        <input
-          type="number"
-          id="tp-ch-start"
-          min="0"
-          step="1"
-          placeholder="0"
-          style="width: 90px"
-        />
-        <label for="tp-ch-end">TP ch end</label>
-        <input
-          type="number"
-          id="tp-ch-end"
-          min="0"
-          step="1"
-          placeholder="all"
-          style="width: 90px"
-        />
-        <button type="button" id="tp-ch-apply">
-          <code>apply ch</code>
-        </button>
-        <button type="button" id="2d-plot">
-          <code>2d plot</code>
-        </button>
-        <button type="button" id="sis_iv">
-          <code>SIS IV</code>
-        </button>
-      </div>
-      <div id="selects">
-        <div id="category-list"></div>
-        <div id="topic-list"></div>
-        <div id="message-fields"></div>
-      </div>
-      <div id="charts">
-        <canvas id="chart"></canvas>
-      </div>
+        <div id="requests">
+            <button type="button" id="ros2-topic-list">
+                <code>ros2 topic list</code>
+            </button>
+            <button type="button" id="total_power">
+                <code>total_power</code>
+            </button>
+            <button type="button" id="2d-plot">
+                <code>2d plot</code>
+            </button>
+            <button type="button" id="sis_iv">
+                <code>SIS IV</code>
+            </button>
+        </div>
+        <div id="selects">
+            <div id="category-list"></div>
+            <div id="topic-list"></div>
+            <div id="message-fields"></div>
+        </div>
+        <div id="charts">
+            <canvas id="chart"></canvas>
+        </div>
     </div>
     <style>
-      .container {
-        padding: 5px 10px;
-        width: 100%;
-        height: calc(100vh - 2em);
-      }
+        .container {
+            padding: 5px 10px;
+            width: 100%;
+            height: calc(100vh - 2em);
+        }
 
-      .charts {
-        width: 100%;
-        height: 100%;
-      }
+        .charts {
+            width: 100%;
+            height: 100%;
+        }
     </style>
-    <script
-      type="module"
-      src="{{url_for('static', filename='index.js')}}"
-    ></script>
-  </body>
+    <script type="module" src="{{url_for('static', filename='index.js')}}"></script>
+</body>
+
 </html>

--- a/observer/templates/qlook/index.html
+++ b/observer/templates/qlook/index.html
@@ -58,7 +58,10 @@
                 <button type="button" class="apply-role-options"><code>apply options</code></button>
             </span>
         </div>
-        <div id="stream-status-list"></div>
+        <details id="stream-status-panel">
+            <summary><code>selected stream status</code></summary>
+            <div id="stream-status-list"></div>
+        </details>
         <div id="selects">
             <div id="category-list"></div>
             <div id="topic-list"></div>
@@ -150,3 +153,4 @@
 </body>
 
 </html>
+

--- a/observer/templates/qlook/index.html
+++ b/observer/templates/qlook/index.html
@@ -26,13 +26,39 @@
             <button type="button" id="total_power">
                 <code>total_power</code>
             </button>
+            <button type="button" id="spectrum_decimated">
+                <code>spectrum_decimated</code>
+            </button>
             <button type="button" id="2d-plot">
                 <code>2d plot</code>
             </button>
             <button type="button" id="sis_iv">
                 <code>SIS IV</code>
             </button>
+            <a href="/debug/streams" target="_blank"><code>debug/streams</code></a>
+            <a href="/debug/sessions" target="_blank"><code>debug/sessions</code></a>
         </div>
+        <div id="status-bar">
+            <code id="connection-status" class="disconnected">connecting</code>
+            <code id="observer-status">observer status unavailable</code>
+            <span id="decimation-controls" class="hidden">
+                <label for="max-points-input"><code>max_points</code></label>
+                <input type="number" id="max-points-input" min="8" max="16384" step="1" value="1024">
+                <label for="decimation-channel-start-input"><code>channel_start</code></label>
+                <input type="number" id="decimation-channel-start-input" step="1" placeholder="0">
+                <label for="decimation-channel-stop-input"><code>channel_stop</code></label>
+                <input type="number" id="decimation-channel-stop-input" step="1" placeholder="end">
+                <button type="button" class="apply-role-options"><code>apply options</code></button>
+            </span>
+            <span id="total-power-controls" class="hidden">
+                <label for="channel-start-input"><code>channel_start</code></label>
+                <input type="number" id="channel-start-input" step="1" placeholder="0">
+                <label for="channel-stop-input"><code>channel_stop</code></label>
+                <input type="number" id="channel-stop-input" step="1" placeholder="end">
+                <button type="button" class="apply-role-options"><code>apply options</code></button>
+            </span>
+        </div>
+        <div id="stream-status-list"></div>
         <div id="selects">
             <div id="category-list"></div>
             <div id="topic-list"></div>
@@ -52,6 +78,72 @@
         .charts {
             width: 100%;
             height: 100%;
+        }
+
+        #requests,
+        #status-bar,
+        #selects,
+        #stream-status-list {
+            display: flex;
+            gap: 8px;
+            flex-wrap: wrap;
+            margin-bottom: 8px;
+        }
+
+        #status-bar code,
+        #stream-status-list code {
+            padding: 2px 6px;
+            border: 1px solid #999;
+            border-radius: 4px;
+            display: inline-block;
+        }
+
+        #connection-status.connected {
+            border-color: #2d7d2d;
+        }
+
+        #connection-status.disconnected {
+            border-color: #a33;
+        }
+
+        #decimation-controls.hidden,
+        #total-power-controls.hidden {
+            display: none;
+        }
+
+        #decimation-controls,
+        #total-power-controls {
+            display: inline-flex;
+            gap: 6px;
+            align-items: center;
+        }
+
+        #max-points-input,
+        #decimation-channel-start-input,
+        #decimation-channel-stop-input,
+        #channel-start-input,
+        #channel-stop-input {
+            width: 7em;
+        }
+
+        .status-chip.live {
+            border-color: #2d7d2d;
+            background: #eef9ee;
+        }
+
+        .status-chip.throttled {
+            border-color: #b57f00;
+            background: #fff8df;
+        }
+
+        .status-chip.stale {
+            border-color: #a33;
+            background: #fdeeee;
+        }
+
+        .status-chip.idle {
+            border-color: #777;
+            background: #f2f2f2;
         }
     </style>
     <script type="module" src="{{url_for('static', filename='index.js')}}"></script>


### PR DESCRIPTION
Closes #107

## 変更内容

Quick Look 機能の大規模アップデート。

### 主な変更ファイル

| ファイル | 変更 |
|---|---|
| `observer/client_manager.py` | +533行 |
| `observer/server.py` | +281行 |
| `observer/static/chart.js` | +442行 |
| `observer/static/index.js` | +320行 |
| `observer/stream_profiles.py` | 新規追加 |
| `observer/stream_keys.py` | 新規追加 |
| `observer/templates/qlook/index.html` | +98行 |

## Test plan

- [ ] コンテナ起動後に observer が正常に立ち上がること
- [ ] Quick Look 画面が表示されること
- [ ] ROS2 トピックのデータがリアルタイムで反映されること