### PR TITLE
#128 fix: replace COPY with git clone for observer source

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,14 +2,13 @@ FROM ghcr.io/necst-telescope/necst:v4.0.20
 
 ENV PATH=$PATH:/root/.local/bin
 ENV PIP_BREAK_SYSTEM_PACKAGES=1
+ENV GIT_TERMINAL_PROMPT=0
 
 RUN curl -sSL https://install.python-poetry.org | python3 - \
     && apt-get update \
     && apt-get install -y python-is-python3
 
-COPY . /root/observer
-
-ENV GIT_TERMINAL_PROMPT=0
+RUN git clone https://github.com/necst-telescope/observer.git /root/observer
 
 RUN cd /root/observer \
     && poetry config virtualenvs.in-project true \


### PR DESCRIPTION
Closes #128

## 変更内容

`COPY . /root/observer` → `RUN git clone https://github.com/necst-telescope/observer.git /root/observer` に変更。

あわせて `ENV GIT_TERMINAL_PROMPT=0` を上部の ENV ブロックにまとめた。

## 理由

`COPY` ではビルドマシン（Mac）の `.git/` がコンテナに入るため、コンテナ内で `git pull` すると認証を求められていた。necst・necst-msgs と同じ `git clone` 方式に統一することで認証なしで `git pull` できるようになる。

## トレードオフ

- ✅ コンテナ内で `git pull` が認証なしで動く
- ✅ necst・necst-msgs と同じ扱いで一貫性が出る
- ❌ ローカルの未push変更はイメージに反映されない

## Test plan

- [x] `docker build` が成功すること
- [x] コンテナ内で `git pull` が認証なしで成功すること