### PR TITLE
Expose Observer ports 8000-8999

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,7 @@ RUN cd /root/observer \
 
 ENV PATH=/root/observer/.venv/bin:$PATH
 
-EXPOSE 8080
+EXPOSE 8000-8999
 
 ENTRYPOINT ["bash", "/entrypoint.sh"]
 CMD ["bash"]


### PR DESCRIPTION
## Summary

Expose ports `8000-8999` from the Observer Docker image instead of only port `8080`.

This is useful on Docker Desktop for macOS, where container ports need to be explicitly published to the host.

## Change

```dockerfile
-EXPOSE 8080
+EXPOSE 8000-8999
```

Runtime publication can then use, for example:

```bash
docker run -p 8000-8999:8000-8999 ...
```

Closes #143