### PR TITLE
#145 Narrow Observer exposed port range to 8000-8099

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,7 @@ RUN cd /root/observer \
 
 ENV PATH=/root/observer/.venv/bin:$PATH
 
-EXPOSE 8000-8999
+EXPOSE 8000-8099
 
 ENTRYPOINT ["bash", "/entrypoint.sh"]
 CMD ["bash"]


### PR DESCRIPTION
## Summary

Reduce the Docker exposed port range from `8000-8999` to `8000-8099`.

## Change

```dockerfile
-EXPOSE 8000-8999
+EXPOSE 8000-8099
```

Closes #145